### PR TITLE
Fix remaining AdvancedFilters import

### DIFF
--- a/src/app/(dashboard)/logistica/page.tsx
+++ b/src/app/(dashboard)/logistica/page.tsx
@@ -20,7 +20,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useDebounce } from "@/hooks/use-debounce";
-import { AdvancedFilters, type FilterOption } from "./_components/AdvancedFilters";
+import { AdvancedFilters, type FilterOption } from "@/components/ui/advanced-filters";
 import Papa from 'papaparse';
 import { saveAs } from 'file-saver';
 import { toast } from "sonner";


### PR DESCRIPTION
## Summary
- adjust logistics page to import AdvancedFilters from the global component

## Testing
- `grep -R "./_components/AdvancedFilters" -n src --exclude-dir=.next --include="*.ts*" --exclude-dir=.git`

------
https://chatgpt.com/codex/tasks/task_e_6841bf019efc8329bac49d9a3d77d89b