### PR TITLE
Ajusta colunas para usar is_active

### DIFF
--- a/src/app/(dashboard)/clientes/page.tsx
+++ b/src/app/(dashboard)/clientes/page.tsx
@@ -27,18 +27,28 @@ export default function ClientesPage() {
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<Record<string, any>>({});
   const [visibleColumns, setVisibleColumns] = useState<string[]>([
-    "name", "email", "phone", "document", "city", "status", "actions"
+    "name",
+    "email",
+    "phone",
+    "document",
+    "city",
+    "is_active",
+    "actions",
   ]);
   
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
 
   // Opções de filtro para clientes
   const filterOptions: FilterOption[] = [
-    { id: "status", label: "Status", type: "select", options: [
-      { value: "Ativo", label: "Ativo" },
-      { value: "Inativo", label: "Inativo" },
-      { value: "Pendente", label: "Pendente" }
-    ]},
+    {
+      id: "is_active",
+      label: "Status",
+      type: "select",
+      options: [
+        { value: true, label: "Ativo" },
+        { value: false, label: "Inativo" },
+      ],
+    },
     { id: "city", label: "Cidade", type: "text" },
     { id: "state", label: "Estado", type: "text" },
     { id: "created_at", label: "Data de Cadastro", type: "date" }
@@ -52,8 +62,8 @@ export default function ClientesPage() {
     { id: "document", label: "Documento" },
     { id: "city", label: "Cidade" },
     { id: "state", label: "Estado" },
-    { id: "status", label: "Status" },
-    { id: "actions", label: "Ações" }
+    { id: "is_active", label: "Status" },
+    { id: "actions", label: "Ações" },
   ];
 
   // Carregar dados dos clientes
@@ -100,7 +110,7 @@ export default function ClientesPage() {
             document: '01471569128',
             city: 'Cuiabá',
             state: 'MT',
-            status: 'Ativo',
+            is_active: true,
             created_at: new Date().toISOString()
           },
           {
@@ -111,7 +121,7 @@ export default function ClientesPage() {
             document: '12345678900',
             city: 'São Paulo',
             state: 'SP',
-            status: 'Ativo',
+            is_active: true,
             created_at: new Date().toISOString()
           }
         ]);
@@ -140,7 +150,7 @@ export default function ClientesPage() {
         Documento: client.document,
         Cidade: client.city,
         Estado: client.state,
-        Status: client.status,
+        Status: client.is_active ? 'Ativo' : 'Inativo',
         'Data de Cadastro': new Date(client.created_at).toLocaleDateString('pt-BR')
       }));
       

--- a/src/app/(dashboard)/fornecedores/_components/SupplierColumns.tsx
+++ b/src/app/(dashboard)/fornecedores/_components/SupplierColumns.tsx
@@ -92,14 +92,22 @@ export const supplierColumns = (onEdit: (supplier: Supplier) => void, onDelete: 
     cell: ({ row }) => <div>{row.original.phone || "-"}</div>,
   },
   {
-    accessorKey: "status",
+    accessorKey: "is_active",
     header: "Status",
     cell: ({ row }) => {
-      const status = row.original.status || "Inativo";
-      return <Badge variant={status === "Ativo" ? "default" : "secondary"}>{status}</Badge>;
+      const isActive = row.original.is_active !== false;
+      return (
+        <Badge variant={isActive ? "default" : "secondary"}>
+          {isActive ? "Ativo" : "Inativo"}
+        </Badge>
+      );
     },
     filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id));
+      const isActive = row.getValue(id) !== false;
+      return (
+        (value.includes("Ativo") && isActive) ||
+        (value.includes("Inativo") && !isActive)
+      );
     },
   },
   {

--- a/src/app/(dashboard)/fornecedores/page.tsx
+++ b/src/app/(dashboard)/fornecedores/page.tsx
@@ -27,18 +27,28 @@ export default function FornecedoresPage() {
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<Record<string, any>>({});
   const [visibleColumns, setVisibleColumns] = useState<string[]>([
-    "name", "fantasy_name", "cnpj", "email", "phone", "status", "actions"
+    "name",
+    "fantasy_name",
+    "cnpj",
+    "email",
+    "phone",
+    "is_active",
+    "actions",
   ]);
   
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
 
   // Opções de filtro para fornecedores
   const filterOptions: FilterOption[] = [
-    { id: "status", label: "Status", type: "select", options: [
-      { value: "Ativo", label: "Ativo" },
-      { value: "Inativo", label: "Inativo" },
-      { value: "Bloqueado", label: "Bloqueado" }
-    ]},
+    {
+      id: "is_active",
+      label: "Status",
+      type: "select",
+      options: [
+        { value: true, label: "Ativo" },
+        { value: false, label: "Inativo" },
+      ],
+    },
     { id: "cnpj", label: "CNPJ", type: "text" },
     { id: "created_at", label: "Data de Cadastro", type: "date" }
   ];
@@ -50,8 +60,8 @@ export default function FornecedoresPage() {
     { id: "cnpj", label: "CNPJ" },
     { id: "email", label: "Email" },
     { id: "phone", label: "Telefone" },
-    { id: "status", label: "Status" },
-    { id: "actions", label: "Ações" }
+    { id: "is_active", label: "Status" },
+    { id: "actions", label: "Ações" },
   ];
 
   // Carregar dados dos fornecedores
@@ -97,7 +107,7 @@ export default function FornecedoresPage() {
             cnpj: '12.345.678/0001-90',
             email: 'contato@textiltech.com.br',
             phone: '11987654321',
-            status: 'Ativo',
+            is_active: true,
             created_at: new Date().toISOString()
           },
           {
@@ -107,7 +117,7 @@ export default function FornecedoresPage() {
             cnpj: '98.765.432/0001-10',
             email: 'vendas@dtntecidos.com.br',
             phone: '21987654321',
-            status: 'Ativo',
+            is_active: true,
             created_at: new Date().toISOString()
           }
         ]);
@@ -135,7 +145,7 @@ export default function FornecedoresPage() {
         'CNPJ': supplier.cnpj,
         'Email': supplier.email,
         'Telefone': supplier.phone,
-        'Status': supplier.status,
+        'Status': supplier.is_active ? 'Ativo' : 'Inativo',
         'Data de Cadastro': new Date(supplier.created_at).toLocaleDateString('pt-BR')
       }));
       

--- a/src/app/(dashboard)/logistica/page.tsx
+++ b/src/app/(dashboard)/logistica/page.tsx
@@ -20,7 +20,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useDebounce } from "@/hooks/use-debounce";
-import { AdvancedFilters, type FilterOption } from "./_components/AdvancedFilters";
+import { AdvancedFilters, type FilterOption } from "@/components/ui/advanced-filters";
 import Papa from 'papaparse';
 import { saveAs } from 'file-saver';
 import { toast } from "sonner";

--- a/src/app/(dashboard)/produtos/_components/ProductColumns.tsx
+++ b/src/app/(dashboard)/produtos/_components/ProductColumns.tsx
@@ -123,14 +123,22 @@ export const productColumns: ColumnDef<Product>[] = [
     cell: ({ row }) => <div className="text-right">{row.original.stock_quantity ?? "-"}</div>,
   },
   {
-    accessorKey: "status",
+    accessorKey: "is_active",
     header: "Status",
     cell: ({ row }) => {
-      const status = row.original.status || "-";
-      return <Badge variant={status === "Ativo" ? "default" : "secondary"}>{status}</Badge>;
+      const isActive = row.original.is_active !== false;
+      return (
+        <Badge variant={isActive ? "default" : "secondary"}>
+          {isActive ? "Ativo" : "Inativo"}
+        </Badge>
+      );
     },
     filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id));
+      const isActive = row.getValue(id) !== false;
+      return (
+        (value.includes("Ativo") && isActive) ||
+        (value.includes("Inativo") && !isActive)
+      );
     },
   },
   {

--- a/src/app/(dashboard)/rh/_components/EmployeeColumns.tsx
+++ b/src/app/(dashboard)/rh/_components/EmployeeColumns.tsx
@@ -88,15 +88,22 @@ export const employeeColumns: ColumnDef<Employee>[] = [
     cell: ({ row }) => <div>{formatDate(row.original.hire_date)}</div>,
   },
   {
-    accessorKey: "status",
+    accessorKey: "is_active",
     header: "Status",
     cell: ({ row }) => {
-      const status = row.original.status || "-";
-      // TODO: Add badge variants based on status
-      return <Badge variant={status === 'Ativo' ? 'default' : 'secondary'}>{status}</Badge>;
+      const isActive = row.original.is_active !== false;
+      return (
+        <Badge variant={isActive ? "default" : "secondary"}>
+          {isActive ? "Ativo" : "Inativo"}
+        </Badge>
+      );
     },
     filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id));
+      const isActive = row.getValue(id) !== false;
+      return (
+        (value.includes("Ativo") && isActive) ||
+        (value.includes("Inativo") && !isActive)
+      );
     },
   },
   {


### PR DESCRIPTION
## Summary
- change Employee/Supplier/Product columns to use `is_active`
- align Clientes and Fornecedores pages with new field names

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf019efc8329bac49d9a3d77d89b