### PR TITLE
feat(auth): aplica controle de acesso baseado em perfil no middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,4 @@ Data | Autor | Descrição
 
 2025-06-07 | CODEX | Ajustada segurança do Supabase via variáveis de ambiente e criado fluxo de confirmação de cadastro. Build ainda falha por erros em módulos externos.
 2025-06-08 | CODEX | Tipagem forte aplicada ao módulo de autenticação, removendo any e utilizando tipos do Supabase.
+2025-06-09 | CODEX | Implementado controle de acesso baseado em perfil no middleware.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -53,6 +53,7 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 ### 🔁 Histórico de Atualizações
 - 2024-06-06: Primeira versão consolidada do CHECKLIST.md (por Renan + squad Olie)
 - (adicione data, autor e resumo da alteração a cada nova atualização)
+- 2025-06-09: Atualizado checklist após inclusão do controle de acesso por perfil (CODEX)
 
 
 **Importante:** Este arquivo deve ser revisado e assinado (digitalmente ou via PR) por todos envolvidos a cada release principal, migração de stack ou inclusão de novo agente/IA. Mantém o Olie ERP sempre auditável, seguro e com evolução controlada!

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+export default function ForbiddenPage() {
+  const router = useRouter();
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="space-y-4 text-center">
+        <h1 className="text-3xl font-bold">Acesso negado</h1>
+        <p className="text-muted-foreground">Você não possui permissão para acessar esta página.</p>
+        <Button onClick={() => router.back()}>Voltar</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -1,0 +1,26 @@
+export enum UserRole {
+  Admin = 'Admin',
+  Financeiro = 'Financeiro',
+  Compras = 'Compras',
+  Producao = 'Producao',
+  RH = 'RH',
+  Logistica = 'Logistica',
+  Treinamento = 'Treinamento'
+}
+
+/** Prefixos de rotas protegidas e os perfis que podem acessá-las */
+export const ACCESS_RULES: { prefix: string; roles: UserRole[] }[] = [
+  { prefix: '/financeiro', roles: [UserRole.Financeiro, UserRole.Admin] },
+  { prefix: '/compras', roles: [UserRole.Compras, UserRole.Admin] },
+  { prefix: '/producao', roles: [UserRole.Producao, UserRole.Admin] },
+  { prefix: '/rh', roles: [UserRole.RH, UserRole.Admin] },
+  { prefix: '/logistica', roles: [UserRole.Logistica, UserRole.Admin] },
+  { prefix: '/treinamento', roles: [UserRole.Treinamento, UserRole.Admin] }
+];
+
+export function canAccessRoute(path: string, userRole?: string | null): boolean {
+  if (!userRole) return false;
+  const rule = ACCESS_RULES.find((r) => path.startsWith(r.prefix));
+  if (!rule) return true;
+  return rule.roles.includes(userRole as UserRole);
+}


### PR DESCRIPTION
## Summary
- implement `canAccessRoute` helper and role rules
- update middleware to redirect unauthenticated or unauthorized users
- persist user role metadata on login
- create friendly `/403` page
- document update in AGENTS.md and CHECKLIST.md

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx -y next build` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed6f577483299cd15ec466681360