### PR TITLE
refactor(financeiro): validação completa com integração de receitas e despesas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,4 @@ Data | Autor | Descrição
 2025-06-10 | CODEX | Módulo de pedidos validado com tipagem e integração.
 2025-06-10 | CODEX | Módulo de produção validado com Kanban e rastreabilidade.
 2025-06-10 | CODEX | Módulo de compras validado com integração estoque/financeiro.
+2025-06-10 | CODEX | Módulo financeiro criado com integração de receitas e despesas.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -69,3 +69,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 - 2025-06-10: Módulo de pedidos validado (CODEX)
 - 2025-06-10: Módulo de produção validado com Kanban e rastreabilidade (CODEX)
 - 2025-06-10: Módulo de compras revisado e validado (CODEX)
+- 2025-06-10: Módulo financeiro criado e integrado (CODEX)

--- a/MODULOS/FINANCEIRO.md
+++ b/MODULOS/FINANCEIRO.md
@@ -1,0 +1,19 @@
+# Módulo Financeiro
+
+Controle de receitas e despesas com integração a pedidos e compras. Permite acompanhar o status de cada lançamento e gerar relatórios de fluxo de caixa.
+
+Campos principais dos lançamentos:
+- id
+- transaction_date
+- amount
+- description
+- type_id (receita ou despesa)
+- category_id
+- payment_method_id
+- status_id
+- reference_type (order|purchase|other)
+- reference_id
+- created_at
+- updated_at
+
+Fluxo básico: ao registrar um pedido ou compra, é criado automaticamente um lançamento financeiro. Os lançamentos podem ser filtrados por status, categoria e período, auxiliando na conciliação bancária e geração de relatórios.

--- a/src/modules/financeiro/DespesaForm.tsx
+++ b/src/modules/financeiro/DespesaForm.tsx
@@ -1,0 +1,19 @@
+"use client";
+import React from 'react';
+import { FinancialTransactionForm } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
+import type { FinancialTransaction } from '@/app/(dashboard)/financeiro/_components/TransactionColumns';
+
+interface DespesaFormProps {
+  initialData?: Partial<FinancialTransaction> & { id?: string };
+  onSuccess: () => void;
+}
+
+export function DespesaForm({ initialData, onSuccess }: DespesaFormProps) {
+  return (
+    <FinancialTransactionForm
+      initialData={initialData}
+      onSuccess={onSuccess}
+      transactionType="Despesa"
+    />
+  );
+}

--- a/src/modules/financeiro/FinanceiroPage.tsx
+++ b/src/modules/financeiro/FinanceiroPage.tsx
@@ -1,0 +1,67 @@
+"use client";
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { fetchLancamentos } from './FinanceiroService';
+import { LancamentosTable } from './LancamentosTable';
+import { ResumoFinanceiro } from './ResumoFinanceiro';
+import { ReceitaForm } from './ReceitaForm';
+import { DespesaForm } from './DespesaForm';
+import type { FinancialTransaction } from '@/app/(dashboard)/financeiro/_components/TransactionColumns';
+
+export default function FinanceiroPage() {
+  const [transactions, setTransactions] = useState<FinancialTransaction[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [openReceita, setOpenReceita] = useState(false);
+  const [openDespesa, setOpenDespesa] = useState(false);
+
+  const loadData = async () => {
+    setIsLoading(true);
+    const result = await fetchLancamentos();
+    if (result.success) setTransactions(result.data);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <ResumoFinanceiro data={transactions} />
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Lançamentos Financeiros</CardTitle>
+          <div className="flex gap-2">
+            <Dialog open={openReceita} onOpenChange={setOpenReceita}>
+              <DialogTrigger asChild>
+                <Button>Novo Receita</Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-[600px]">
+                <DialogHeader>
+                  <DialogTitle>Lançar Receita</DialogTitle>
+                </DialogHeader>
+                <ReceitaForm onSuccess={() => { setOpenReceita(false); loadData(); }} />
+              </DialogContent>
+            </Dialog>
+            <Dialog open={openDespesa} onOpenChange={setOpenDespesa}>
+              <DialogTrigger asChild>
+                <Button variant="outline">Nova Despesa</Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-[600px]">
+                <DialogHeader>
+                  <DialogTitle>Lançar Despesa</DialogTitle>
+                </DialogHeader>
+                <DespesaForm onSuccess={() => { setOpenDespesa(false); loadData(); }} />
+              </DialogContent>
+            </Dialog>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <LancamentosTable data={transactions} loading={isLoading} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/financeiro/FinanceiroService.ts
+++ b/src/modules/financeiro/FinanceiroService.ts
@@ -1,0 +1,67 @@
+import { createClient } from '@/lib/supabase/client';
+import { handleSupabaseError, createRecord, updateRecord, deleteRecord } from '@/lib/data-hooks';
+import type { LancamentoFormValues } from './financeiro.schema';
+import type { LancamentoFinanceiro, Categoria, FormaDePagamento } from './financeiro.types';
+
+export async function fetchLancamentos(query: Record<string, unknown> = {}) {
+  try {
+    const supabase = createClient();
+    let builder = supabase
+      .from('financial_transactions')
+      .select('*, category:category_id(id,name), payment_method:payment_method_id(id,name), status:status_id(id,name,color)')
+      .order('transaction_date', { ascending: false });
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        builder = builder.eq(key, value as string);
+      }
+    });
+
+    const { data, error } = await builder;
+    if (error) return handleSupabaseError(error);
+    return { success: true, data } as { success: true; data: LancamentoFinanceiro[] };
+  } catch (error) {
+    return handleSupabaseError(error);
+  }
+}
+
+export async function createLancamento(data: LancamentoFormValues) {
+  return createRecord<LancamentoFinanceiro>('financial_transactions', data);
+}
+
+export async function updateLancamento(id: string, data: LancamentoFormValues) {
+  return updateRecord<LancamentoFinanceiro>('financial_transactions', id, data);
+}
+
+export async function deleteLancamento(id: string) {
+  return deleteRecord('financial_transactions', id);
+}
+
+export async function fetchCategorias() {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('financial_categories')
+      .select('id,name')
+      .order('name');
+    if (error) return handleSupabaseError(error);
+    return { success: true, data } as { success: true; data: Categoria[] };
+  } catch (error) {
+    return handleSupabaseError(error);
+  }
+}
+
+export async function fetchFormasPagamento() {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('payment_methods')
+      .select('id,name')
+      .eq('is_active', true)
+      .order('name');
+    if (error) return handleSupabaseError(error);
+    return { success: true, data } as { success: true; data: FormaDePagamento[] };
+  } catch (error) {
+    return handleSupabaseError(error);
+  }
+}

--- a/src/modules/financeiro/LancamentosTable.tsx
+++ b/src/modules/financeiro/LancamentosTable.tsx
@@ -1,0 +1,13 @@
+"use client";
+import React from 'react';
+import { DataTable } from '@/components/ui/data-table';
+import { transactionColumns, type FinancialTransaction } from '@/app/(dashboard)/financeiro/_components/TransactionColumns';
+
+interface LancamentosTableProps {
+  data: FinancialTransaction[];
+  loading?: boolean;
+}
+
+export function LancamentosTable({ data, loading }: LancamentosTableProps) {
+  return <DataTable columns={transactionColumns} data={data} loading={loading} />;
+}

--- a/src/modules/financeiro/ReceitaForm.tsx
+++ b/src/modules/financeiro/ReceitaForm.tsx
@@ -1,0 +1,19 @@
+"use client";
+import React from 'react';
+import { FinancialTransactionForm } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
+import type { FinancialTransaction } from '@/app/(dashboard)/financeiro/_components/TransactionColumns';
+
+interface ReceitaFormProps {
+  initialData?: Partial<FinancialTransaction> & { id?: string };
+  onSuccess: () => void;
+}
+
+export function ReceitaForm({ initialData, onSuccess }: ReceitaFormProps) {
+  return (
+    <FinancialTransactionForm
+      initialData={initialData}
+      onSuccess={onSuccess}
+      transactionType="Receita"
+    />
+  );
+}

--- a/src/modules/financeiro/ResumoFinanceiro.tsx
+++ b/src/modules/financeiro/ResumoFinanceiro.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React from 'react';
+import type { FinancialTransaction } from '@/app/(dashboard)/financeiro/_components/TransactionColumns';
+
+interface ResumoFinanceiroProps {
+  data: FinancialTransaction[];
+}
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+export function ResumoFinanceiro({ data }: ResumoFinanceiroProps) {
+  const receitas = data.filter(t => t.is_income).reduce((sum, t) => sum + t.amount, 0);
+  const despesas = data.filter(t => !t.is_income).reduce((sum, t) => sum + t.amount, 0);
+  const saldo = receitas - despesas;
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div className="p-4 rounded-md bg-green-50 dark:bg-green-900/30">
+        <p className="text-sm">Receitas</p>
+        <p className="text-xl font-bold">{formatCurrency(receitas)}</p>
+      </div>
+      <div className="p-4 rounded-md bg-red-50 dark:bg-red-900/30">
+        <p className="text-sm">Despesas</p>
+        <p className="text-xl font-bold">{formatCurrency(despesas)}</p>
+      </div>
+      <div className="p-4 rounded-md bg-gray-50 dark:bg-gray-800/30">
+        <p className="text-sm">Saldo</p>
+        <p className="text-xl font-bold">{formatCurrency(saldo)}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/financeiro/financeiro.schema.ts
+++ b/src/modules/financeiro/financeiro.schema.ts
@@ -1,0 +1,15 @@
+import * as z from 'zod';
+
+export const lancamentoSchema = z.object({
+  transaction_date: z.date({ required_error: 'Data é obrigatória' }),
+  amount: z.number({ required_error: 'Valor é obrigatório' }).positive(),
+  description: z.string().min(3, 'Descrição obrigatória'),
+  category_id: z.string().uuid({ message: 'Categoria inválida' }),
+  payment_method_id: z.string().uuid({ message: 'Forma de pagamento inválida' }),
+  reference_type: z.enum(['order', 'purchase', 'other']).optional(),
+  reference_id: z.string().uuid().optional(),
+  status_id: z.string().uuid({ message: 'Status inválido' }),
+  type_id: z.string().uuid({ message: 'Tipo inválido' })
+});
+
+export type LancamentoFormValues = z.infer<typeof lancamentoSchema>;

--- a/src/modules/financeiro/financeiro.types.ts
+++ b/src/modules/financeiro/financeiro.types.ts
@@ -1,0 +1,18 @@
+import type { FinancialTransaction, FinancialCategory, PaymentMethod, GlobalStatus } from '@/types/schema';
+
+export interface LancamentoFinanceiro extends FinancialTransaction {
+  category?: Pick<FinancialCategory, 'id' | 'name'> | null;
+  payment_method?: Pick<PaymentMethod, 'id' | 'name'> | null;
+  status?: Pick<GlobalStatus, 'id' | 'name' | 'color'> | null;
+}
+
+export interface Conta {
+  id: string;
+  name: string;
+  bank?: string | null;
+  number?: string | null;
+  balance: number;
+}
+
+export type Categoria = FinancialCategory;
+export type FormaDePagamento = PaymentMethod;


### PR DESCRIPTION
## Summary
- add financial module service and types
- add finance pages and forms
- document finance module
- update agents and checklist logs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684719c166288329be6d0cd9183f4974