### PR TITLE
Fix lint and imports for auth and estoque

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';

--- a/src/lib/auth-hooks.ts
+++ b/src/lib/auth-hooks.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useEffect } from 'react';

--- a/src/modules/estoque/EstoquePage.tsx
+++ b/src/modules/estoque/EstoquePage.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { DataTable } from "@/components/ui/data-table";
-import { columns } from "./_components/StockItemColumns";
+import { columns } from "@/app/(dashboard)/estoque/_components/StockItemColumns";
 import { Plus, FileDown, FileUp, Filter } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -14,7 +14,7 @@ import { AdvancedFilters, type FilterOption } from "@/components/ui/advanced-fil
 import Papa from 'papaparse';
 import { saveAs } from 'file-saver';
 import { toast } from "sonner";
-import { StockItemForm } from "./_components/StockItemForm";
+import { StockItemForm } from "@/app/(dashboard)/estoque/_components/StockItemForm";
 import { useSupabaseData } from "@/lib/data-hooks";
 import { fetchStockItems } from "./EstoqueService";
 import type { Insumo } from "./estoque.types";

--- a/src/modules/logistica/LogisticaPage.tsx
+++ b/src/modules/logistica/LogisticaPage.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EntregasTable } from './EntregasTable';
 import { EntregaForm } from './EntregaForm';
 import { ResumoLogistica } from './ResumoLogistica';
+import { DataTable } from "@/components/ui/data-table";
 import { deliveryColumns, type Delivery } from "@/app/(dashboard)/logistica/_components/DeliveryColumns";
 import { deliveryRouteColumns, type DeliveryRoute } from "@/app/(dashboard)/logistica/_components/DeliveryRouteColumns";
 import { DeliveryRouteForm } from "@/app/(dashboard)/logistica/_components/DeliveryRouteForm";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,6 @@
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": [
-    "node_modules",
-    "src/contexts/auth-context.tsx",
-    "src/lib/auth-hooks.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` from auth files
- update StockItem imports in EstoquePage
- import DataTable in LogisticaPage
- clean tsconfig exclusions

## Testing
- `npm run lint`
- `npm run type-check` *(fails: numerous TS errors)*
- `npx next build` *(fails: prerender error)*

------
https://chatgpt.com/codex/tasks/task_e_6847351d3f4883299908918b8087912f