### PR TITLE
Fix AuthSessionMissingError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,4 @@ Data | Autor | Descrição
 2025-06-10 | CODEX | Módulo de BI validado com dashboards por setor.
 2025-06-11 | CODEX | Módulo de RH estruturado com colaboradores e produtividade.
 2025-06-12 | CODEX | Autenticação passa a usar `supabase.auth.getUser()` para validar usuário, substituindo `getSession` e confiabilidade em eventos.
+2025-06-13 | CODEX | Corrigido erro `AuthSessionMissingError` garantindo que `getUser()` seja chamado apenas após `onAuthStateChange('INITIAL_SESSION')`.

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -224,18 +224,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     };
     
-    loadUserAndPermissions();
-    
-    // Configurar listener para mudanças de autenticação
+    // Configurar listener para mudanças de autenticação e sessão inicial
     const { data: authListener } = supabase.auth.onAuthStateChange(
       async (event) => {
-        if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-          const { data: { user } } = await supabase.auth.getUser();
-          if (user) {
-            setUser(user);
-            setIsAuthenticated(true);
-            await loadUserAndPermissions();
-          }
+        if (
+          event === 'INITIAL_SESSION' ||
+          event === 'SIGNED_IN' ||
+          event === 'TOKEN_REFRESHED'
+        ) {
+          await loadUserAndPermissions();
         } else if (event === 'SIGNED_OUT') {
           setUser(null);
           setProfile(null);
@@ -243,6 +240,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           setPermissions([]);
           setModules([]);
           setIsAuthenticated(false);
+          setIsLoading(false);
         }
       }
     );


### PR DESCRIPTION
## Summary
- only load user after Supabase session initialized
- document AuthSessionMissingError fix in AGENTS notes

## Testing
- `npm test`
- `npm run lint`
- `npx next build` *(fails: Export encountered an error on /estoque/movimentacoes/page)*

------
https://chatgpt.com/codex/tasks/task_e_68482d8a0b7c832981f91c5a42477a81