### PR TITLE
Fix movements page build issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,4 @@ Data | Autor | Descrição
 2025-06-11 | CODEX | Módulo de RH estruturado com colaboradores e produtividade.
 2025-06-12 | CODEX | Autenticação passa a usar `supabase.auth.getUser()` para validar usuário, substituindo `getSession` e confiabilidade em eventos.
 2025-06-13 | CODEX | Corrigido erro `AuthSessionMissingError` garantindo que `getUser()` seja chamado apenas após `onAuthStateChange('INITIAL_SESSION')`.
+2025-06-14 | CODEX | Corrigido build de `/estoque/movimentacoes` separando wrapper server e MovementsPageClient.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -60,6 +60,7 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 
 - 2025-06-09: Login module fully validated (CODEX)
 - 2025-06-09: Movimentacoes estoque refatorado para separar lógica client/server (CODEX)
+- 2025-06-14: Rota de movimentações refatorada com wrapper server e componente client isolado (CODEX)
 - 2025-06-10: Módulo de clientes revisado e validado (CODEX)
 - 2025-06-10: Módulo de clientes revisado e validado (CODEX)
 - 2025-06-09: Módulo de fornecedores revisado e validado (CODEX)

--- a/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
+++ b/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
@@ -25,7 +25,7 @@ async function getMovements(): Promise<StockMovement[]> {
   return [];
 }
 
-export default function MovementsPageClient() {
+export function MovementsPageClient() {
   const [isFormOpen, setIsFormOpen] = React.useState(false);
   const [movements, setMovements] = React.useState<StockMovement[]>([]);
   // Editing movements is generally not recommended, focus on creation and viewing

--- a/src/app/(dashboard)/estoque/movimentacoes/page.tsx
+++ b/src/app/(dashboard)/estoque/movimentacoes/page.tsx
@@ -1,5 +1,10 @@
-import MovementsPageClient from "./_components/MovementsPageClient";
+import { Suspense } from 'react';
+import { MovementsPageClient } from "./_components/MovementsPageClient";
 
 export default function MovimentacoesEstoquePage() {
-  return <MovementsPageClient />;
+  return (
+    <Suspense fallback={<div>Carregando...</div>}>
+      <MovementsPageClient />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap movements page with Suspense and expose client page as named export
- update agents and checklist logs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: requires next package)*

------
https://chatgpt.com/codex/tasks/task_e_684831f717888329a930e8fb20e3165d