### PR TITLE
Fix duplicated finance forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,4 +93,5 @@ Data | Autor | Descrição
 2025-06-10 | CODEX | Ajustado RH com histórico tipado e imports corretos.
 2025-06-10 | CODEX | BI validado com serviços retornando arrays tipados.
 2025-06-10 | CODEX | Ajustes parciais no financeiro; build falha em /logistica.
+2025-06-18 | CODEX | Nova tentativa de estabilização final. Corrigidos formulários duplicados no módulo financeiro. Type-check e build ainda apresentam falhas, especialmente em /logistica.
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -83,4 +83,5 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 - 2025-06-10: BI integrado ao painel com serviços tipados (CODEX)
 
 - 2025-06-10: Correções pendentes impedem build final (CODEX)
+ 2025-06-18: Nova tentativa de estabilização, build ainda falha em /logistica e persiste erros de tipagem (CODEX)
 

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -33,3 +33,6 @@ Os testes de lint foram executados com sucesso e o build foi executado até a et
 ## Financeiro
 - Ajustes parciais realizados, porém erros de tipagem persistem e o build falha em `/logistica`.
 
+## Conclusão Final
+Apesar das correções adicionais nos formulários de receitas e despesas, o `type-check` ainda reporta inúmeras falhas nos módulos de cadastro e o `next build` interrompe a geração da página `/logistica` com erro de renderização. Nova rodada de refatoração será necessária antes do deploy.
+

--- a/src/modules/financeiro/DespesaForm.tsx
+++ b/src/modules/financeiro/DespesaForm.tsx
@@ -1,14 +1,13 @@
 "use client";
 import React from 'react';
 import { FinancialTransactionForm } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
-import type { FinancialTransactionFormValues } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
-interface DespesaFormProps {
-  initialData?: Partial<FinancialTransactionFormValues> & { id?: string };
 import type { LancamentoFinanceiro } from './financeiro.types';
+
 interface DespesaFormProps {
   initialData?: Partial<LancamentoFinanceiro> & { id?: string };
   onSuccess: () => void;
 }
+
 export function DespesaForm({ initialData, onSuccess }: DespesaFormProps) {
   return (
     <FinancialTransactionForm

--- a/src/modules/financeiro/ReceitaForm.tsx
+++ b/src/modules/financeiro/ReceitaForm.tsx
@@ -1,14 +1,13 @@
 "use client";
 import React from 'react';
 import { FinancialTransactionForm } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
-import type { FinancialTransactionFormValues } from '@/app/(dashboard)/financeiro/_components/FinancialTransactionForm';
-interface ReceitaFormProps {
-  initialData?: Partial<FinancialTransactionFormValues> & { id?: string };
 import type { LancamentoFinanceiro } from './financeiro.types';
+
 interface ReceitaFormProps {
   initialData?: Partial<LancamentoFinanceiro> & { id?: string };
   onSuccess: () => void;
 }
+
 export function ReceitaForm({ initialData, onSuccess }: ReceitaFormProps) {
   return (
     <FinancialTransactionForm


### PR DESCRIPTION
## Summary
- fix ReceitaForm and DespesaForm exports
- update docs about remaining build problems

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails)*
- `npx next build` *(fails)*


------
https://chatgpt.com/codex/tasks/task_e_684873ff8b508329b9b535a93d885bbc