### PR TITLE
Partial type cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,4 @@ Data | Autor | Descrição
 2025-06-18 | CODEX | Nova tentativa de estabilização final. Corrigidos formulários duplicados no módulo financeiro. Type-check e build ainda apresentam falhas, especialmente em /logistica.
 
 2025-06-19 | CODEX | Client table fix for logística and partial type updates; build ainda apresenta erros de tipagem.
+2025-06-11 | CODEX | Pequenos ajustes de tipagem e props; build ainda falha na pagina /logistica.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -86,3 +86,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
  2025-06-18: Nova tentativa de estabilização, build ainda falha em /logistica e persiste erros de tipagem (CODEX)
 
 2025-06-19: Ajustes parciais na tipagem e componente de entregas convertido para client (CODEX)
+2025-06-11: Tentativa de estabilizacao final. Type-check e build ainda falham.

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -37,3 +37,4 @@ Os testes de lint foram executados com sucesso e o build foi executado até a et
 Apesar das correções adicionais nos formulários de receitas e despesas, o `type-check` ainda reporta inúmeras falhas nos módulos de cadastro e o `next build` interrompe a geração da página `/logistica` com erro de renderização. Nova rodada de refatoração será necessária antes do deploy.
 
 \n## 2025-06-19\nParciais correções no módulo de logística e tipagens. Build ainda não estabilizado.
+2025-06-11: Tentativa de estabilizacao pelo CODEX; type-check e build seguem falhando em diversos modulos.

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -44,11 +44,12 @@ export default function LoginPage() {
     } else {
       // Armazena o perfil em user_metadata para facilitar o middleware
       try {
+        type RoleQueryResult = { role: { name: string } | null } | null;
         const { data: roleData } = await supabase
           .from('user_roles')
           .select('role:roles(name)')
           .eq('user_id', data.user.id)
-          .single();
+          .single<RoleQueryResult>();
 
         const roleName = roleData?.role?.name;
         if (roleName) {

--- a/src/app/(dashboard)/clientes/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/clientes/[id]/edit/page.tsx
@@ -25,7 +25,7 @@ export default function EditClientPage() {
       const result = await getRecordById('clients', params.id as string);
       
       if (result.success) {
-        setClient(result.data);
+        setClient(result.data || null);
       } else {
         setError('Cliente não encontrado.');
       }

--- a/src/app/(dashboard)/clientes/[id]/page.tsx
+++ b/src/app/(dashboard)/clientes/[id]/page.tsx
@@ -25,7 +25,7 @@ export default function ClientDetailsPage() {
       const result = await getRecordById('clients', params.id as string);
       
       if (result.success) {
-        setClient(result.data);
+        setClient(result.data || null);
       } else {
         setError('Cliente não encontrado.');
       }

--- a/src/app/(dashboard)/componentes/page.tsx
+++ b/src/app/(dashboard)/componentes/page.tsx
@@ -318,7 +318,7 @@ export default function ComponentesPage() {
           <DataTable
             columns={columns.filter(col => visibleColumns.includes(col.id))}
             data={components}
-            isLoading={isLoading}
+            loading={isLoading}
             onRowClick={(row) => handleComponentClick(row.id)}
           />
         </CardContent>

--- a/src/app/(dashboard)/configuracoes/auditoria/page.tsx
+++ b/src/app/(dashboard)/configuracoes/auditoria/page.tsx
@@ -384,7 +384,7 @@ export default function AuditLogPage() {
           <DataTable
             columns={columns}
             data={logs}
-            isLoading={isLoading}
+            loading={isLoading}
             pageCount={Math.ceil(totalLogs / pageSize)}
             pageIndex={page}
             pageSize={pageSize}

--- a/src/app/(dashboard)/insumos/page.tsx
+++ b/src/app/(dashboard)/insumos/page.tsx
@@ -325,7 +325,7 @@ export default function InsumosPage() {
           <DataTable
             columns={columns.filter(col => visibleColumns.includes(col.id))}
             data={insumos}
-            isLoading={isLoading}
+            loading={isLoading}
             onRowClick={(row) => handleInsumoClick(row.id)}
           />
         </CardContent>

--- a/src/modules/estoque/EstoquePage.tsx
+++ b/src/modules/estoque/EstoquePage.tsx
@@ -299,7 +299,7 @@ export default function EstoquePage() {
           <DataTable
             columns={columns.filter(col => visibleColumns.includes(col.id))}
             data={stockItems}
-            isLoading={isLoading}
+            loading={isLoading}
             onRowClick={(row) => handleItemClick(row.id)}
           />
         </CardContent>


### PR DESCRIPTION
## Summary
- fix login role fetch typing
- update client pages to handle optional data
- adjust `DataTable` prop to `loading`
- document failed stabilization attempt

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails)*
- `npx next build` *(fails)*


------
https://chatgpt.com/codex/tasks/task_e_684976d05370832996fb36f97c348fe4