### PR TITLE
Partial fixes for final stabilization

### DIFF
--- a/src/app/(dashboard)/clientes/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/clientes/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ export default function EditClientPage() {
       setLoading(true);
       setError(null);
       
-      const result = await getRecordById('clients', params.id as string);
+      const result = await getRecordById<Client>('clients', params.id as string);
       
       if (result.success) {
         setClient(result.data || null);

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -38,6 +38,7 @@ interface DataTableProps<TData, TValue> {
   loading?: boolean
   searchKey?: string
   meta?: any
+  onRowClick?: (row: TData) => void
 }
 
 export function DataTable<TData, TValue>({
@@ -46,6 +47,7 @@ export function DataTable<TData, TValue>({
   loading = false,
   searchKey,
   meta,
+  onRowClick,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
@@ -153,6 +155,8 @@ export function DataTable<TData, TValue>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
+                  onClick={() => onRowClick?.(row.original)}
+                  className={onRowClick ? 'cursor-pointer' : undefined}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>


### PR DESCRIPTION
## Summary
- use correct generic on client edit page
- add optional row click support in DataTable

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails)*
- `npx next build` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68497c4e5c6c8329b04e4480f4146fdf