### PR TITLE
Fix estoque advanced filters and typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Data | Autor | Descrição
 2025-06-18 | CODEX | Nova tentativa de estabilização final. Corrigidos formulários duplicados no módulo financeiro. Type-check e build ainda apresentam falhas, especialmente em /logistica.
 
 2025-06-19 | CODEX | Client table fix for logística and partial type updates; build ainda apresenta erros de tipagem.
+2025-06-19 | CODEX | Ajustado módulo de estoque para tipagem segura e filtros avançados.
 2025-06-11 | CODEX | Pequenos ajustes de tipagem e props; build ainda falha na pagina /logistica.
 2025-06-11 | CODEX | Validação do módulo de clientes concluída; type-check limpo para diretórios de clientes.
 2025-06-11 | CODEX | Módulo de fornecedores validado com tipagens e colunas. Type-check limpo para fornecedores.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -87,5 +87,6 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
  2025-06-18: Nova tentativa de estabilização, build ainda falha em /logistica e persiste erros de tipagem (CODEX)
 
 2025-06-19: Ajustes parciais na tipagem e componente de entregas convertido para client (CODEX)
+2025-06-19: Módulo de estoque atualizado com filtros avançados e tipagens corrigidas (CODEX)
 2025-06-11: Tentativa de estabilizacao final. Type-check e build ainda falham.
 2025-06-11: Módulo de clientes validado; erros de tipagem resolvidos (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -41,4 +41,5 @@ Os testes de lint foram executados com sucesso e o build foi executado até a et
 Apesar das correções adicionais nos formulários de receitas e despesas, o `type-check` ainda reporta inúmeras falhas nos módulos de cadastro e o `next build` interrompe a geração da página `/logistica` com erro de renderização. Nova rodada de refatoração será necessária antes do deploy.
 
 \n## 2025-06-19\nParciais correções no módulo de logística e tipagens. Build ainda não estabilizado.
+2025-06-19: Módulo de estoque revisado com filtros e tipagens corrigidos. Build continua falhando em /logistica.
 2025-06-11: Tentativa de estabilizacao pelo CODEX; type-check e build seguem falhando em diversos modulos.

--- a/src/app/(dashboard)/estoque/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/estoque/[id]/edit/page.tsx
@@ -13,7 +13,7 @@ import { StockItemForm } from '../../_components/StockItemForm';
 export default function EditStockItemPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
-  const [stockItem, setStockItem] = useState<StockItem | null>(null);
+  const [stockItem, setStockItem] = useState<Partial<StockItem> | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,20 +22,7 @@ export default function EditStockItemPage() {
       setLoading(true);
       setError(null);
       
-      const result = await getRecordById('stock_items', params.id as string, {
-        select: `
-          id, 
-          name, 
-          sku, 
-          location_id, 
-          quantity, 
-          min_quantity,
-          unit_of_measurement_id, 
-          group_id,
-          is_active,
-          updated_at
-        `
-      });
+      const result = await getRecordById<StockItem>('stock_items', params.id as string);
       
       if (result.success) {
         setStockItem(result.data);

--- a/src/app/(dashboard)/estoque/_components/AdvancedFilters.tsx
+++ b/src/app/(dashboard)/estoque/_components/AdvancedFilters.tsx
@@ -12,7 +12,7 @@ export interface FilterOption {
   id: string;
   label: string;
   options?: { value: string; label: string }[];
-  type: 'text' | 'select' | 'date';
+  type: 'text' | 'select' | 'date' | 'boolean';
 }
 
 interface FilterValues {
@@ -22,12 +22,18 @@ interface FilterValues {
 interface AdvancedFiltersProps {
   filterOptions: FilterOption[];
   onFilterChange: (filters: FilterValues) => void;
+  columnOptions: { id: string; label: string }[];
+  visibleColumns: string[];
+  onVisibleColumnsChange: (columns: string[]) => void;
   className?: string;
 }
 
 export const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({
   filterOptions,
   onFilterChange,
+  columnOptions,
+  visibleColumns,
+  onVisibleColumnsChange,
   className = '',
 }) => {
   const [expanded, setExpanded] = React.useState(false);
@@ -132,6 +138,24 @@ export const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({
                 )}
               </div>
             ))}
+            <div className="space-y-2 md:col-span-2">
+              <Label>Colunas Visíveis</Label>
+              {columnOptions.map((opt) => (
+                <div key={opt.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={visibleColumns.includes(opt.id)}
+                    onChange={(e) => {
+                      const updated = e.target.checked
+                        ? [...visibleColumns, opt.id]
+                        : visibleColumns.filter((c) => c !== opt.id);
+                      onVisibleColumnsChange(updated);
+                    }}
+                  />
+                  <span>{opt.label}</span>
+                </div>
+              ))}
+            </div>
           </div>
         </CardContent>
       )}

--- a/src/app/(dashboard)/estoque/_components/EstoqueTable.tsx
+++ b/src/app/(dashboard)/estoque/_components/EstoqueTable.tsx
@@ -36,7 +36,7 @@ export default function EstoqueTable() {
   const [searchTerm, setSearchTerm] = useState("");
   const [isFormDialogOpen, setIsFormDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [currentItem, setCurrentItem] = useState<StockItem | null>(null);
+  const [currentItem, setCurrentItem] = useState<Partial<StockItem> | null>(null);
   
   // Usar o hook genérico para buscar dados do estoque
   const { 
@@ -249,9 +249,9 @@ export default function EstoqueTable() {
               {currentItem ? "Editar Item de Estoque" : "Adicionar Item de Estoque"}
             </DialogTitle>
           </DialogHeader>
-          <StockItemForm 
-            initialData={currentItem} 
-            onSuccess={handleFormSuccess} 
+          <StockItemForm
+            initialData={currentItem ?? undefined}
+            onSuccess={handleFormSuccess}
           />
         </DialogContent>
       </Dialog>

--- a/src/app/(dashboard)/estoque/_components/StockItemColumns.tsx
+++ b/src/app/(dashboard)/estoque/_components/StockItemColumns.tsx
@@ -91,10 +91,10 @@ export const stockItemColumns = (onEdit: (item: Insumo) => void, onDelete: (item
       if (!isActive) {
         status = "Inativo";
         variant = "secondary";
-      } else if (row.original.min_quantity !== null && row.original.quantity <= row.original.min_quantity) {
+      } else if (row.original.min_quantity != null && row.original.quantity <= row.original.min_quantity) {
         status = "Crítico";
         variant = "destructive";
-      } else if (row.original.min_quantity !== null && row.original.quantity <= row.original.min_quantity * 1.5) {
+      } else if (row.original.min_quantity != null && row.original.quantity <= row.original.min_quantity * 1.5) {
         status = "Baixo";
         variant = "outline";
       }

--- a/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
+++ b/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
@@ -19,7 +19,7 @@ import {
 async function getMovements(): Promise<StockMovement[]> {
   const result = await fetchMovimentacoes();
   if (result.success) {
-    return result.data || [];
+    return (result.data as StockMovement[]) || [];
   }
   console.warn('Nenhuma movimentação encontrada');
   return [];

--- a/src/components/ui/advanced-filters.tsx
+++ b/src/components/ui/advanced-filters.tsx
@@ -33,16 +33,19 @@ type FilterFormValues = z.infer<typeof filterFormSchema>;
 export type FilterOption = {
   id: string;
   label: string;
-  type: "text" | "select" | "date";
+  type: "text" | "select" | "date" | "boolean";
   options?: { value: string; label: string }[];
 };
 
 interface AdvancedFiltersProps {
   filterOptions: FilterOption[];
   onFilterChange: (filters: { [key: string]: string }) => void;
+  columnOptions?: { id: string; label: string }[];
+  visibleColumns?: string[];
+  onVisibleColumnsChange?: (cols: string[]) => void;
 }
 
-export function AdvancedFilters({ filterOptions, onFilterChange }: AdvancedFiltersProps) {
+export function AdvancedFilters({ filterOptions, onFilterChange, columnOptions = [], visibleColumns = [], onVisibleColumnsChange }: AdvancedFiltersProps) {
   const form = useForm<FilterFormValues>({
     resolver: zodResolver(filterFormSchema),
     defaultValues: {},
@@ -114,14 +117,48 @@ export function AdvancedFilters({ filterOptions, onFilterChange }: AdvancedFilte
                         value={field.value || ""}
                       />
                     )}
+                    {option.type === "boolean" && (
+                      <Select onValueChange={field.onChange} value={field.value || ""}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Selecione" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="true">Sim</SelectItem>
+                          <SelectItem value="false">Não</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    )}
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
-          ))}
+      ))}
         </div>
-        <div className="flex justify-end space-x-2">
+        {columnOptions.length > 0 && (
+          <div className="mt-4 space-y-2">
+            <FormLabel>Colunas Visíveis</FormLabel>
+            {columnOptions.map((opt) => (
+              <div key={opt.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={visibleColumns.includes(opt.id)}
+                  onChange={(e) => {
+                    if (!onVisibleColumnsChange) return;
+                    const updated = e.target.checked
+                      ? [...visibleColumns, opt.id]
+                      : visibleColumns.filter((c) => c !== opt.id);
+                    onVisibleColumnsChange(updated);
+                  }}
+                />
+                <span>{opt.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex justify-end space-x-2 mt-4">
           <Button
             type="button"
             variant="outline"

--- a/src/modules/estoque/EstoquePage.tsx
+++ b/src/modules/estoque/EstoquePage.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useDebounce } from "@/hooks/use-debounce";
 import { AdvancedFilters, type FilterOption } from "@/components/ui/advanced-filters";
 import Papa from 'papaparse';
+import type { ParseResult } from 'papaparse';
 import { saveAs } from 'file-saver';
 import { toast } from "sonner";
 import { StockItemForm } from "@/app/(dashboard)/estoque/_components/StockItemForm";
@@ -113,9 +114,10 @@ export default function EstoquePage() {
 
       if (result.success) {
         setStockItems(result.data || []);
+        setError(null);
       } else {
         setStockItems([]);
-        setError(result.error || 'Erro ao buscar itens de estoque');
+        setError('error' in result ? result.error : 'Erro ao buscar itens de estoque');
       }
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error('Unknown error');
@@ -163,7 +165,7 @@ export default function EstoquePage() {
 
     Papa.parse(file, {
       header: true,
-      complete: async (results) => {
+      complete: async (results: ParseResult<Record<string, unknown>>) => {
         try {
           // Aqui você implementaria a lógica para salvar os itens importados
           // Por enquanto, apenas mostramos uma mensagem de sucesso
@@ -275,7 +277,7 @@ export default function EstoquePage() {
           {isFiltersOpen && (
             <div className="mb-6">
               <AdvancedFilters
-                options={filterOptions}
+                filterOptions={filterOptions}
                 onFilterChange={setActiveFilters}
                 columnOptions={columnOptions}
                 visibleColumns={visibleColumns}
@@ -297,7 +299,7 @@ export default function EstoquePage() {
           )}
 
           <DataTable
-            columns={columns.filter(col => visibleColumns.includes(col.id))}
+            columns={columns.filter(col => typeof col.id === 'string' && visibleColumns.includes(col.id))}
             data={stockItems}
             loading={isLoading}
             onRowClick={(row) => handleItemClick(row.id)}


### PR DESCRIPTION
## Summary
- add boolean filter option support
- handle visible columns in advanced filters
- improve estoque page type safety
- adjust stock item utilities for strict types
- document progress in AGENTS and CHECKLIST

## Testing
- `npm test`
- `npm run lint` *(fails: warnings only)*
- `npx next build` *(failed: React.Children.only error on /logistica)*

------
https://chatgpt.com/codex/tasks/task_e_684995d8adf08329a3770148e0294ab4