### PR TITLE
Fix dropdown menu triggers in logistcia

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,4 @@ Data | Autor | Descrição
 
 
 2025-06-20 | CODEX | Revisada logistica garantindo filhos únicos em triggers. Build estabilizado.
+2025-06-20 | CODEX | Ajustados triggers de menu em logística para usar `asChild`.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -95,3 +95,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 2025-06-20: Popover wrappers simplificados no módulo de logística; build ainda falha (CODEX)
 
 2025-06-20: Triggers revisados em logística garantindo ReactElement único (CODEX)
+2025-06-20: Dropdown triggers convertidos para `asChild` em logística (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -48,3 +48,4 @@ Apesar das correções adicionais nos formulários de receitas e despesas, o `ty
 2025-06-20: Ajuste adicional em triggers de data picker; erro persiste na página /logistica.
 
 2025-06-20: Triggers corrigidos garantindo filho único; build agora finaliza sem erros.
+2025-06-20: Ajustados menus dropdown com `asChild` no módulo de logística.

--- a/src/app/(dashboard)/logistica/_components/DeliveryColumns.tsx
+++ b/src/app/(dashboard)/logistica/_components/DeliveryColumns.tsx
@@ -114,7 +114,12 @@ export const deliveryColumns: ColumnDef<Delivery, DeliveryTableMeta>[] = [
 
       return (
         <DropdownMenu>
-          <DropdownMenuTrigger><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Abrir menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel>Ações</DropdownMenuLabel>
             <DropdownMenuItem onClick={() => meta?.viewDetails(delivery.id)}>

--- a/src/app/(dashboard)/logistica/_components/DeliveryRouteColumns.tsx
+++ b/src/app/(dashboard)/logistica/_components/DeliveryRouteColumns.tsx
@@ -133,7 +133,12 @@ export const deliveryRouteColumns = (
 
         return (
         <DropdownMenu>
-          <DropdownMenuTrigger><Button variant="ghost" className="h-8 w-8 p-0"><span className="sr-only">Abrir menu</span><MoreHorizontal className="h-4 w-4" /></Button></DropdownMenuTrigger>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Abrir menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel>Ações</DropdownMenuLabel>
             <DropdownMenuItem


### PR DESCRIPTION
## Summary
- update dropdown menu triggers to use `asChild`
- document final trigger fix in logistica module

## Testing
- `npm run lint`
- `npm test`
- `npx next build` *(fails: React.Children.only expected to receive a single React element child)*

------
https://chatgpt.com/codex/tasks/task_e_6849b13a89f88329b071e341b8135043