### PR TITLE
Fix asChild in Button

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
@@ -42,7 +43,18 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? React.Fragment : "button"
+    const Comp = asChild ? Slot : "button"
+    if (asChild) {
+      const { children } = props
+      if (
+        !React.isValidElement(children) ||
+        React.Children.count(children) !== 1
+      ) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error("Button with 'asChild' expects a single React element child.")
+        }
+      }
+    }
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}


### PR DESCRIPTION
## Summary
- enforce single child usage when using `asChild` prop in Button
- swap Fragment for Slot to correctly forward props

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: needs next@15.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5fd95fc8329a77fa093bcfc164e