### PR TITLE
Fix clients module types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,4 @@ Data | Autor | Descrição
 2025-06-23 | CODEX | Ajustados módulos de produção, financeiro, RH, BI e auditoria para tipagem segura e build estável.
 
 2025-06-24 | CODEX | Ajustes de tipagem adicionais em componentes e pages; type-check segue com falhas.
+2025-06-25 | CODEX | Módulo clientes estabilizado com tipagem

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -90,6 +90,7 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 2025-06-19: Módulo de estoque atualizado com filtros avançados e tipagens corrigidas (CODEX)
 2025-06-11: Tentativa de estabilizacao final. Type-check e build ainda falham.
 2025-06-11: Módulo de clientes validado; erros de tipagem resolvidos (CODEX)
+2025-06-25: Módulo de clientes estabilizado com tipagem (CODEX)
 2025-06-20: Logística ajustada removendo `asChild` para estabilizar build (CODEX)
 
 2025-06-20: Popover wrappers simplificados no módulo de logística; build ainda falha (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -55,3 +55,4 @@ Apesar das correções adicionais nos formulários de receitas e despesas, o `ty
 2025-06-23: Módulos de produção, financeiro, RH, BI e auditoria revisados para eliminar erros de tipagem e garantir build.
 
 2025-06-24: Refino parcial de tipagens; tsc exibe erros pendentes em pedidos e producao.
+2025-06-25: Módulo de clientes estabilizado com tipagem. Formulários revisados e components tipados.

--- a/src/app/(dashboard)/clientes/[id]/page.tsx
+++ b/src/app/(dashboard)/clientes/[id]/page.tsx
@@ -21,8 +21,8 @@ export default function ClientDetailsPage() {
     try {
       setLoading(true);
       setError(null);
-      
-      const result = await getRecordById('clients', params.id as string);
+
+      const result = await getRecordById<Client>('clients', params.id as string);
       
       if (result.success) {
         setClient(result.data || null);

--- a/src/app/(dashboard)/clientes/_components/ClientForm.tsx
+++ b/src/app/(dashboard)/clientes/_components/ClientForm.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import {
@@ -44,7 +44,7 @@ interface ClientFormProps {
 
 export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
   const form = useForm<ClientFormValues>({
-    resolver: zodResolver(clientFormSchema),
+    resolver: zodResolver(clientFormSchema) as Resolver<ClientFormValues>,
     defaultValues: {
       name: initialData?.name || "",
       email: initialData?.email || "",
@@ -94,7 +94,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Nome */}
-          <FormField
+          <FormField<ClientFormValues, "name">
             control={form.control}
             name="name"
             render={({ field }) => (
@@ -109,7 +109,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           />
 
           {/* Email */}
-          <FormField
+          <FormField<ClientFormValues, "email">
             control={form.control}
             name="email"
             render={({ field }) => (
@@ -124,7 +124,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           />
 
           {/* Telefone */}
-          <FormField
+          <FormField<ClientFormValues, "phone">
             control={form.control}
             name="phone"
             render={({ field }) => (
@@ -139,7 +139,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           />
 
           {/* CPF/CNPJ */}
-          <FormField
+          <FormField<ClientFormValues, "document">
             control={form.control}
             name="document"
             render={({ field }) => (
@@ -155,7 +155,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
         </div>
 
         {/* Endereço */}
-        <FormField
+        <FormField<ClientFormValues, "address">
           control={form.control}
           name="address"
           render={({ field }) => (
@@ -171,7 +171,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {/* Cidade */}
-          <FormField
+          <FormField<ClientFormValues, "city">
             control={form.control}
             name="city"
             render={({ field }) => (
@@ -186,7 +186,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           />
 
           {/* Estado */}
-          <FormField
+          <FormField<ClientFormValues, "state">
             control={form.control}
             name="state"
             render={({ field }) => (
@@ -201,7 +201,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           />
 
           {/* CEP */}
-          <FormField
+          <FormField<ClientFormValues, "postal_code">
             control={form.control}
             name="postal_code"
             render={({ field }) => (
@@ -217,7 +217,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
         </div>
 
         {/* Observações */}
-        <FormField
+        <FormField<ClientFormValues, "notes">
           control={form.control}
           name="notes"
           render={({ field }) => (
@@ -237,7 +237,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
         />
 
         {/* Status */}
-        <FormField
+        <FormField<ClientFormValues, "is_active">
           control={form.control}
           name="is_active"
           render={({ field }) => (


### PR DESCRIPTION
## Summary
- stabilize types for ClientForm and details page
- document update in AGENTS, CHECKLIST, and final report

## Testing
- `npm run type-check` *(fails: other modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ace53b3c883298b3de73c66b5580e