### PR TITLE
Fix Insumos param checks

### DIFF
--- a/src/app/(dashboard)/insumos/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/insumos/[id]/edit/page.tsx
@@ -8,11 +8,12 @@ import { ArrowLeft, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { getRecordById } from '@/lib/data-hooks';
 import { InsumoForm } from '../../_components/InsumoForm';
+import type { Insumo } from '@/modules/estoque/estoque.types';
 
 export default function EditInsumoPage() {
   const params = useParams();
   const router = useRouter();
-  const [insumo, setInsumo] = useState<any>(null);
+  const [insumo, setInsumo] = useState<Insumo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,6 +57,8 @@ export default function EditInsumoPage() {
     fetchInsumo();
   }, [params.id]);
 
+  if (!params?.id) return null;
+
   const handleSuccess = () => {
     toast.success('Insumo atualizado com sucesso');
     router.push(`/insumos/${params.id}`);
@@ -98,10 +101,9 @@ export default function EditInsumoPage() {
         </CardHeader>
         <CardContent>
           {insumo && (
-            <InsumoForm 
-              initialData={insumo} 
+            <InsumoForm
+              initialData={insumo}
               onSuccess={handleSuccess}
-              isEditing={true}
             />
           )}
         </CardContent>

--- a/src/app/(dashboard)/insumos/[id]/page.tsx
+++ b/src/app/(dashboard)/insumos/[id]/page.tsx
@@ -119,6 +119,8 @@ export default function SupplyDetailsPage() {
     }
   }, [params.id, supabase]);
 
+  if (!params?.id) return null;
+
   const handleEdit = () => {
     // Abrir modal de edição ou navegar para página de edição
     // Por enquanto, apenas mostra um alerta

--- a/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
+++ b/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import type { Insumo } from "@/modules/estoque/estoque.types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -39,7 +40,7 @@ const insumoFormSchema = z.object({
 type InsumoFormValues = z.infer<typeof insumoFormSchema>;
 
 interface InsumoFormProps {
-  initialData?: any; // Para edição
+  initialData?: Partial<Insumo>; // Para edição
   onSuccess?: () => void; // Callback após submissão bem-sucedida
 }
 


### PR DESCRIPTION
## Summary
- add Insumo type to InsumoForm props
- ensure Insumo edit/detail pages check params after hooks

## Testing
- `npm run lint`
- `npx next build`
- `npm run type-check` *(fails: TS errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_684af4d0f00883298f2c4faa87dc695b