### PR TITLE
Fix fornecedores module typings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,4 @@ Data | Autor | Descrição
 2025-06-30 | CODEX | Logistica module fully typed & build-clean
 2025-06-30 | CODEX | Produtos module fully typed & build-clean
 2025-06-30 | CODEX | Kits module fully typed & build-clean
+2025-07-01 | CODEX | Reapplied fixes to Fornecedores module with typed CSV import.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -117,3 +117,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 2025-06-30: Logistica module fully typed & build-clean (CODEX)
 2025-06-30: Produtos module fully typed & build-clean (CODEX)
 2025-06-30: Kits module fully typed & build-clean (CODEX)
+2025-07-01: Fornecedores module refactored after reset (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -69,3 +69,4 @@ Apesar das correções adicionais nos formulários de receitas e despesas, o `ty
 2025-06-30: Logistica module fully typed & build-clean (CODEX)
 2025-06-30: Produtos module fully typed & build-clean (CODEX)
 2025-06-30: Kits module fully typed & build-clean (CODEX)
+2025-07-01: Fornecedores module revalidated with CSV import typing.

--- a/src/modules/fornecedores/FornecedoresPage.tsx
+++ b/src/modules/fornecedores/FornecedoresPage.tsx
@@ -17,7 +17,15 @@ import {
 } from "@/components/ui/dialog";
 import { useDebounce } from "@/hooks/use-debounce";
 import { AdvancedFilters, type FilterOption } from "@/components/ui/advanced-filters";
-import Papa, { type ParseError, type ParseResult } from "papaparse";
+import Papa from "papaparse";
+
+interface CSVParseResult<T> {
+  data: T[];
+}
+
+interface CSVParseError {
+  message: string;
+}
 import { saveAs } from "file-saver";
 import { toast } from "sonner";
 import { SupplierForm } from "@/app/(dashboard)/fornecedores/_components/SupplierForm";
@@ -119,13 +127,13 @@ export default function FornecedoresPage() {
   const importFromCSV = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
-    Papa.parse<Record<string, unknown>>(file, {
+    Papa.parse(file, {
       header: true,
-      complete: (results) => {
+      complete: (results: CSVParseResult<Record<string, unknown>>) => {
         toast.success(`${results.data.length} fornecedores importados com sucesso!`);
         fetchSuppliers();
       },
-      error: (error) => {
+      error: (error: CSVParseError) => {
         console.error("Erro ao processar arquivo CSV:", error);
         toast.error("Erro ao processar arquivo CSV.");
       },


### PR DESCRIPTION
## Summary
- fix CSV parse typings in `FornecedoresPage`
- log updates for fornecedores fixes

## Testing
- `npm run lint`
- `npm run type-check` *(fails: TS errors remain in other modules)*
- `npm test`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_684c4e7cac348329b1cb1d3d2d195e71