### PR TITLE
Fix RH module typings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,4 @@ Data | Autor | Descrição
 2025-06-30 | CODEX | Produtos module fully typed & build-clean
 2025-06-30 | CODEX | Kits module fully typed & build-clean
 2025-07-01 | CODEX | Reapplied fixes to Fornecedores module with typed CSV import.
+2025-07-01 | CODEX | RH module typing updated; explicit return types added.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -118,3 +118,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 2025-06-30: Produtos module fully typed & build-clean (CODEX)
 2025-06-30: Kits module fully typed & build-clean (CODEX)
 2025-07-01: Fornecedores module refactored after reset (CODEX)
+2025-07-01: RH module return types clarified and lint clean (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -70,3 +70,4 @@ Apesar das correções adicionais nos formulários de receitas e despesas, o `ty
 2025-06-30: Produtos module fully typed & build-clean (CODEX)
 2025-06-30: Kits module fully typed & build-clean (CODEX)
 2025-07-01: Fornecedores module revalidated with CSV import typing.
+2025-07-01: RH module typed with explicit React return types.

--- a/src/modules/rh/RHPage.tsx
+++ b/src/modules/rh/RHPage.tsx
@@ -11,7 +11,7 @@ import { ColaboradorForm } from './components/ColaboradorForm';
 import { colaboradorColumns, type ColaboradorRow } from './components/ColaboradoresTable';
 import { fetchColaboradores } from './RHService';
 
-export default function RHPage() {
+export default function RHPage(): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [colaboradores, setColaboradores] = useState<ColaboradorRow[]>([]);

--- a/src/modules/rh/components/ColaboradorForm.tsx
+++ b/src/modules/rh/components/ColaboradorForm.tsx
@@ -15,7 +15,7 @@ interface ColaboradorFormProps {
   onSuccess?: () => void;
 }
 
-export function ColaboradorForm({ initialData, onSuccess }: ColaboradorFormProps) {
+export function ColaboradorForm({ initialData, onSuccess }: ColaboradorFormProps): React.ReactElement {
   const form = useForm<ColaboradorFormValues>({
     resolver: zodResolver(colaboradorSchema),
     defaultValues: initialData || { name: '' },

--- a/src/modules/rh/components/ColaboradoresTable.tsx
+++ b/src/modules/rh/components/ColaboradoresTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from 'react';
 import { ColumnDef } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/modules/rh/components/HistoricoProdutividade.tsx
+++ b/src/modules/rh/components/HistoricoProdutividade.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import React from 'react';
 import type { HistoricoProducao } from '../rh.types';
 
 interface HistoricoProdutividadeProps {
   historico: HistoricoProducao[];
 }
 
-export function HistoricoProdutividade({ historico }: HistoricoProdutividadeProps) {
+export function HistoricoProdutividade({ historico }: HistoricoProdutividadeProps): React.ReactElement {
   return (
     <table className="w-full text-sm">
       <thead>


### PR DESCRIPTION
## Summary
- add explicit React return types to RH components
- ensure React import present for table and history components
- log RH module validation in docs

## Testing
- `npm run lint`
- `npm run type-check` *(fails: other modules only)*
- `npm test`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_684c5c9405b08329961c48e3bad304e0