### PR TITLE
Fix login component typing and environment validation

### DIFF
--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type SubmitHandler } from "react-hook-form";
+import type { FC } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
@@ -37,7 +38,7 @@ const credentialsSchema = z.object({
 
 export type CredentialsSchema = z.infer<typeof credentialsSchema>;
 
-export default function LoginForm(): JSX.Element {
+const LoginForm: FC = () => {
   const router = useRouter();
   const supabase = createClient();
 
@@ -147,5 +148,7 @@ export default function LoginForm(): JSX.Element {
       </Card>
     </div>
   );
-}
+};
+
+export default LoginForm;
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -4,10 +4,14 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ExtendedDatabase } from "@/types/extended-supabase";
 
 export function createClient(): SupabaseClient<ExtendedDatabase> {
-  return createBrowserClient<ExtendedDatabase>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error("Supabase credentials are missing in environment variables");
+  }
+
+  return createBrowserClient<ExtendedDatabase>(url, anonKey);
 }
 
 export const createSupabaseClient = createClient;


### PR DESCRIPTION
## Summary
- validate environment variables before creating Supabase client
- convert LoginForm to typed React component

## Testing
- `npm run type-check` *(fails: ParseResult errors)*
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ca4343ef88329b33d7dac67d6a2b0