### PR TITLE
Fix typed UI components

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -38,7 +38,10 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, children, ...props }, ref) => {
+  (
+    { className, variant, size, asChild = false, children, ...props },
+    ref,
+  ): React.ReactElement => {
     const Comp = asChild ? Slot : "button"
 
     // Verificação de segurança para uso com asChild

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,22 +4,21 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref): React.JSX.Element => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
+  ({ className, type = "text", ...props }, ref): React.ReactElement => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
 )
 Input.displayName = "Input"
 


### PR DESCRIPTION
## Summary
- type `Input` defaults and return value
- make `Button` return typed element and clean lint

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `npx next build` *(fails: prompts for package installation)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8917180832981adb95191636157