### PR TITLE
Fully type src/lib and hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,4 @@ Data | Autor | Descrição
 A validacao total do repositorio nao foi possivel dentro do escopo atual devido a centenas de erros de tipagem ainda existentes em multiplos modulos. As principais areas corrigidas foram: clientes, fornecedores, financeiro, estoque, logistica, pedidos, compras, producao, BI e RH.
 Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabilizar 100% do codigo.
 2025-06-16 | CODEX | UI components folder typed and validated
+2025-06-16 | CODEX | lib + hooks fully typed – 2025-06-16

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -128,3 +128,4 @@ Este arquivo centraliza os checklists de tarefas, validações e revisões para 
 A validacao total do repositorio nao foi possivel dentro do escopo atual devido a centenas de erros de tipagem ainda existentes em multiplos modulos. As principais areas corrigidas foram: clientes, fornecedores, financeiro, estoque, logistica, pedidos, compras, producao, BI e RH.
 Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabilizar 100% do codigo.
 2025-06-16 – UI components folder typed and validated
+2025-06-16: lib + hooks fully typed – 2025-06-16 (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -80,3 +80,4 @@ Validação final executada sem erros de tipagem
 A validacao total do repositorio nao foi possivel dentro do escopo atual devido a centenas de erros de tipagem ainda existentes em multiplos modulos. As principais areas corrigidas foram: clientes, fornecedores, financeiro, estoque, logistica, pedidos, compras, producao, BI e RH.
 Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabilizar 100% do codigo.
 2025-06-16 – UI components folder typed and validated
+2025-06-16: lib + hooks fully typed – 2025-06-16

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,32 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * Simple hook to get the current authenticated user.
+ * It listens for auth state changes and updates the user accordingly.
+ */
+export function useAuth(): User | null {
+  const supabase = useMemo(() => createClient(), []);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const getInitialUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      setUser(data.user);
+    };
+
+    void getInitialUser();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  return user;
+}

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,17 +1,17 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState } from "react";
 
-export function useDebounce<T>(value: T, delay?: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+export function useDebounce<T>(value: T, delay = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay || 500)
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
 
     return () => {
-      clearTimeout(timer)
-    }
-  }, [value, delay])
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
 
-  return debouncedValue
+  return debouncedValue;
 }

--- a/src/lib/data-hooks.ts
+++ b/src/lib/data-hooks.ts
@@ -8,7 +8,8 @@ import {
   Client,
   Supplier,
   StockItem,
-  Component
+  Component,
+  Supply
 } from '@/types/schema';
 
 export { useSupabaseData } from './utils/data-hooks';
@@ -56,7 +57,8 @@ export const createRecord = async <T>(
       .from(table)
       .insert(cleanData)
       .select()
-      .single();
+      .single()
+      .returns<T>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -93,7 +95,8 @@ export const updateRecord = async <T>(
       .update(cleanData)
       .eq('id', id)
       .select()
-      .single();
+      .single()
+      .returns<T>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -269,7 +272,8 @@ export const getStockItems = async (query: Record<string, unknown> = {}) => {
       const { data, error } = await supabase
         .from('stock_items')
         .select('*, group:group_id(*), location:location_id(*), unit_of_measurement:unit_of_measurement_id(*)')
-        .lt('quantity', supabase.rpc('get_field_ref', { table_name: 'stock_items', row_id: 'id', field_name: 'min_quantity' }));
+        .lt('quantity', supabase.rpc('get_field_ref', { table_name: 'stock_items', row_id: 'id', field_name: 'min_quantity' }))
+        .returns<StockItem[]>();
       
       if (error) {
         return handleSupabaseError(error);
@@ -328,7 +332,7 @@ export const getStockItems = async (query: Record<string, unknown> = {}) => {
       }
     });
     
-    const { data, error } = await queryBuilder;
+    const { data, error } = await queryBuilder.returns<StockItem[]>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -348,7 +352,8 @@ export const getStockItemById = async (id: string) => {
       .from('stock_items')
       .select('*, group:group_id(*), location:location_id(*), unit_of_measurement:unit_of_measurement_id(*)')
       .eq('id', id)
-      .single();
+      .single()
+      .returns<StockItem>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -419,7 +424,7 @@ export const getComponents = async (query: Record<string, unknown> = {}) => {
       }
     });
     
-    const { data, error } = await queryBuilder;
+    const { data, error } = await queryBuilder.returns<Component[]>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -439,7 +444,8 @@ export const getComponentById = async (id: string) => {
       .from('components')
       .select('*, category:category_id(*), unit_of_measurement:unit_of_measurement_id(*)')
       .eq('id', id)
-      .single();
+      .single()
+      .returns<Component>();
     
     if (error) {
       return handleSupabaseError(error);
@@ -474,7 +480,8 @@ export const getSupplies = async (query: Record<string, unknown> = {}) => {
       const { data, error } = await supabase
         .from('supplies')
         .select('*, supplier:supplier_id(*), unit_of_measurement:unit_of_measurement_id(*)')
-        .lt('quantity', supabase.rpc('get_field_ref', { table_name: 'supplies', row_id: 'id', field_name: 'min_quantity' }));
+        .lt('quantity', supabase.rpc('get_field_ref', { table_name: 'supplies', row_id: 'id', field_name: 'min_quantity' }))
+        .returns<Supply[]>();
       
       if (error) {
         return handleSupabaseError(error);
@@ -533,7 +540,7 @@ export const getSupplies = async (query: Record<string, unknown> = {}) => {
       }
     });
     
-    const { data, error } = await queryBuilder;
+    const { data, error } = await queryBuilder.returns<Supply[]>();
     
     if (error) {
       return handleSupabaseError(error);

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -14,4 +14,4 @@ export function createClient(): SupabaseClient<ExtendedDatabase> {
   return createBrowserClient<ExtendedDatabase>(url, anonKey);
 }
 
-export const createSupabaseClient = createClient;
+export const createSupabaseClient: () => SupabaseClient<ExtendedDatabase> = createClient;

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,8 +1,11 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ExtendedDatabase } from "@/types/extended-supabase";
 
-export async function createSupabaseMiddlewareClient(req: NextRequest) {
+export async function createSupabaseMiddlewareClient(
+  req: NextRequest
+): Promise<{ supabase: SupabaseClient<ExtendedDatabase>; response: NextResponse }> {
   // Cria uma resposta inicial
   const response = NextResponse.next();
 

--- a/src/lib/supabase/server-alternative.ts
+++ b/src/lib/supabase/server-alternative.ts
@@ -1,11 +1,12 @@
 "use client";
 
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ExtendedDatabase } from "@/types/extended-supabase";
 
 // Versão alternativa do cliente Supabase para uso em componentes
 // que não suportam o uso de next/headers
-export function createSupabaseServerClientAlternative() {
+export function createSupabaseServerClientAlternative(): SupabaseClient<ExtendedDatabase> {
   return createBrowserClient<ExtendedDatabase>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,8 +1,9 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ExtendedDatabase } from "@/types/extended-supabase";
 
-export async function createSupabaseServerClient() {
+export async function createSupabaseServerClient(): Promise<SupabaseClient<ExtendedDatabase>> {
   const cookieStore = await cookies();
 
   return createServerClient<ExtendedDatabase>(


### PR DESCRIPTION
## Summary
- ensure Supabase createClient helpers return typed clients
- add explicit types to middleware/server utilities
- type data hook queries with `.returns`
- add reusable `useAuth` hook and refine `useDebounce`
- document validation in AGENTS, CHECKLIST and final reports

## Testing
- `npm run lint`
- `npm test`
- `npx next build`
- `npm run type-check` *(fails outside lib and hooks)*

------
https://chatgpt.com/codex/tasks/task_e_685041a9f8348329adfea031c2f32d2c