### PR TITLE
Type login and root pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,4 @@ Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabil
 2025-06-16 | CODEX | lib + hooks fully typed – 2025-06-16
 2025-06-16 | CODEX | components (non-ui) fully typed – 2025-06-16
 2025-07-03 | CODEX | kits module fully typed – 2025-07-03
+2025-07-04 | CODEX | auth, layouts and root pages fully typed – 2025-07-04

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -131,3 +131,4 @@ Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabil
 2025-06-16: lib + hooks fully typed – 2025-06-16 (CODEX)
 2025-06-16 – components (non-ui) fully typed – 2025-06-16
 2025-07-03: Kits module fully typed – CODEX
+2025-07-04: Auth, layouts and root pages fully typed (CODEX)

--- a/relatorio_validacao_final.md
+++ b/relatorio_validacao_final.md
@@ -83,3 +83,4 @@ Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabil
 2025-06-16: lib + hooks fully typed – 2025-06-16
 2025-06-16 – components (non-ui) fully typed – 2025-06-16
 2025-07-03: Kits module fully typed – build clean (CODEX)
+2025-07-04: Auth, layouts and root pages fully typed (CODEX)

--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import * as React from "react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import type { FC } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
@@ -38,7 +38,7 @@ const credentialsSchema = z.object({
 
 export type CredentialsSchema = z.infer<typeof credentialsSchema>;
 
-const LoginForm: FC = () => {
+const LoginForm: React.FC = (): React.ReactElement => {
   const router = useRouter();
   const supabase = createClient();
 
@@ -61,12 +61,14 @@ const LoginForm: FC = () => {
     }
 
     try {
-      type RoleQueryResult = { role: { name: string } | null } | null;
-      const { data: roleData } = await supabase
+      type RoleQueryResult = { role: { name: string } | null };
+      const roleQuery = await supabase
         .from("user_roles")
         .select("role:roles(name)")
         .eq("user_id", data.user.id)
-        .single<RoleQueryResult>();
+        .returns<RoleQueryResult>()
+        .maybeSingle();
+      const roleData = roleQuery.data as RoleQueryResult | null;
 
       const roleName = roleData?.role?.name;
       if (roleName) {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,10 +1,10 @@
 // src/app/(auth)/login/page.tsx
 "use client";
 
-import type { FC } from "react";
+import * as React from "react";
 import LoginForm from "./components/LoginForm";
 
-const LoginPage: FC = () => {
+const LoginPage: React.FC = (): React.ReactElement => {
   return <LoginForm />;
 };
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+interface ErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+const GlobalError: React.FC<ErrorProps> = ({ error, reset }): React.ReactElement => {
+  React.useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 text-center">
+      <h2 className="text-2xl font-bold">Algo deu errado!</h2>
+      <button onClick={() => reset()} className="underline">
+        Tentar novamente
+      </button>
+    </div>
+  );
+};
+
+export default GlobalError;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
-import './globals.css'
-import { Inter } from 'next/font/google'
-import { AuthProvider } from '@/contexts/auth-context'
-import { ProvidersWrapper } from '@/contexts/providers-wrapper'
-import { Toaster } from '@/components/ui/toaster'
+import "./globals.css";
+import * as React from "react";
+import { Inter } from "next/font/google";
+import { AuthProvider } from "@/contexts/auth-context";
+import { ProvidersWrapper } from "@/contexts/providers-wrapper";
+import { Toaster } from "@/components/ui/toaster";
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -11,11 +12,11 @@ export const metadata = {
   description: 'Sistema de gestão empresarial para Olie Ateliê',
 }
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const RootLayout: React.FC<LayoutProps> = ({ children }): React.ReactElement => {
   return (
     <html lang="pt-BR">
       <body className={inter.className}>
@@ -27,5 +28,7 @@ export default function RootLayout({
         </AuthProvider>
       </body>
     </html>
-  )
-}
+  );
+};
+
+export default RootLayout;

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+
+const Loading: React.FC = (): React.ReactElement => (
+  <div className="flex items-center justify-center min-h-screen">
+    <Loader2 className="h-6 w-6 animate-spin" />
+  </div>
+);
+
+export default Loading;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const NotFound: React.FC = (): React.ReactElement => (
+  <div className="flex flex-col items-center justify-center min-h-screen gap-4 text-center">
+    <h2 className="text-3xl font-bold">Página não encontrada</h2>
+    <Button asChild>
+      <Link href="/">Voltar para o início</Link>
+    </Button>
+  </div>
+);
+
+export default NotFound;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import * as React from "react";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/auth-context";
 
-export default function Home() {
+const Home: React.FC = (): React.ReactElement => {
   const router = useRouter();
   const { user, isLoading } = useAuth();
   const [loadingTimeout, setLoadingTimeout] = useState(false);
@@ -148,4 +149,6 @@ export default function Home() {
       </div>
     </div>
   );
-}
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- type login form and page
- type root layout and home page
- add global `error`, `loading` and `not-found` pages
- document progress in AGENTS, CHECKLIST, and reports

## Testing
- `npm run type-check` *(fails: errors in dashboard modules only)*
- `npm run lint`
- `npm test`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_68504a4016588329bbc9db94d670e1e2