### PR TITLE
Fix data-hooks exports and build errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,3 +148,4 @@ Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabil
 2025-06-16 | CODEX | Componentes module typed and validated – 2025-06-16
 2025-06-16 | CODEX | Insumos module typed and validated – 2025-06-16
 \n2025-07-06 | CODEX | Hooks and lint adjustments; skeleton component added
+2025-07-07 | CODEX | Restored data-hooks exports and build passing

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -137,3 +137,4 @@ Um novo ciclo de refatoracao sera necessario para zerar o `type-check` e estabil
 2025-06-16: Componentes module typed and validated – CODEX
 2025-06-16: Insumos module typed and validated – CODEX
 - 2025-07-06: Hooks and lint fixes by CODEX
+- 2025-07-07: Data hooks restored and build stabilized (CODEX)

--- a/src/app/(dashboard)/clientes/_components/ClientForm.tsx
+++ b/src/app/(dashboard)/clientes/_components/ClientForm.tsx
@@ -17,7 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
-import { createRecord, updateRecord } from "@/lib/utils/data-hooks";
+import { createRecord, updateRecord } from "@/lib/data-hooks";
 import type { Client } from "@/types/schema";
 import { Switch } from "@/components/ui/switch";
 

--- a/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
+++ b/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
-import { createRecord, updateRecord } from "@/lib/utils/data-hooks";
+import { createRecord, updateRecord } from "@/lib/data-hooks";
 import { Switch } from "@/components/ui/switch";
 import type { Supplier } from "@/types/schema";
 

--- a/src/lib/data-hooks.ts
+++ b/src/lib/data-hooks.ts
@@ -70,3 +70,175 @@ export async function getSupplies(filters: Record<string, unknown> = {}): Promis
 
   return { success: true, data: data as any[] };
 }
+
+// --- Generic Supabase helpers ---
+export function handleSupabaseError(error: unknown): { success: false; error: string } {
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message: string }).message)
+      : "Erro ao acessar o banco de dados";
+  console.error("Supabase error:", error);
+  return { success: false, error: message } as const;
+}
+
+export async function createRecord<T>(
+  table: string,
+  data: Partial<T>
+): Promise<{ success: boolean; data?: T; error?: string }> {
+  try {
+    const supabase = createClient();
+    const cleanData: Record<string, unknown> = {};
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        cleanData[key] = value;
+      }
+    });
+
+    const { data: result, error } = await supabase
+      .from(table)
+      .insert(cleanData)
+      .select()
+      .single()
+      .returns<T>();
+    if (error) return handleSupabaseError(error);
+    return { success: true, data: result as T };
+  } catch (err) {
+    return handleSupabaseError(err);
+  }
+}
+
+export async function updateRecord<T>(
+  table: string,
+  id: string,
+  data: Partial<T>
+): Promise<{ success: boolean; data?: T; error?: string }> {
+  try {
+    const supabase = createClient();
+    const cleanData: Record<string, unknown> = {};
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        cleanData[key] = value;
+      }
+    });
+    cleanData.updated_at = new Date().toISOString();
+    const { data: result, error } = await supabase
+      .from(table)
+      .update(cleanData)
+      .eq("id", id)
+      .select()
+      .single()
+      .returns<T>();
+    if (error) return handleSupabaseError(error);
+    return { success: true, data: result as T };
+  } catch (err) {
+    return handleSupabaseError(err);
+  }
+}
+
+export async function deleteRecord(
+  table: string,
+  id: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = createClient();
+    const { error } = await supabase.from(table).delete().eq("id", id);
+    if (error) return handleSupabaseError(error);
+    return { success: true };
+  } catch (err) {
+    return handleSupabaseError(err);
+  }
+}
+
+export async function getRecordById<T>(
+  table: string,
+  id: string
+): Promise<{ success: boolean; data?: T; error?: string }> {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from(table)
+      .select("*")
+      .eq("id", id)
+      .single()
+      .returns<T>();
+    if (error) return handleSupabaseError(error);
+    return { success: true, data: data as T };
+  } catch (err) {
+    return handleSupabaseError(err);
+  }
+}
+
+export async function getRecords<T>(
+  table: string,
+  query: Record<string, unknown> = {}
+): Promise<{ success: boolean; data?: T[]; error?: string }> {
+  try {
+    const supabase = createClient();
+    let builder = supabase.from(table).select("*");
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== "") {
+        if (typeof value === "string" && value.startsWith("ilike.")) {
+          builder = builder.ilike(key, value.replace("ilike.", ""));
+        } else {
+          builder = builder.eq(key, value as string);
+        }
+      }
+    });
+    const { data, error } = await builder.returns<T[]>();
+    if (error) return handleSupabaseError(error);
+    return { success: true, data: Array.isArray(data) ? (data as T[]) : [] };
+  } catch (err) {
+    return handleSupabaseError(err);
+  }
+}
+
+// --- Entity helpers ---
+import type { Client, Supplier, StockItem, Component } from "@/types/schema";
+
+export const getClients = (query: Record<string, unknown> = {}) =>
+  getRecords<Client>("clients", query);
+
+export const getSuppliers = (query: Record<string, unknown> = {}) =>
+  getRecords<Supplier>("suppliers", query);
+
+export const getSupplierById = (id: string) =>
+  getRecordById<Supplier>("suppliers", id);
+
+export const createSupplier = (data: Partial<Supplier>) =>
+  createRecord<Supplier>("suppliers", data);
+
+export const updateSupplier = (id: string, data: Partial<Supplier>) =>
+  updateRecord<Supplier>("suppliers", id, data);
+
+export const deleteSupplier = (id: string) =>
+  deleteRecord("suppliers", id);
+
+export const getStockItems = async (
+  query: Record<string, unknown> = {}
+): Promise<{ success: boolean; data?: StockItem[]; error?: string }> => {
+  const lowStock = Boolean(query.low_stock);
+  if ("low_stock" in query) delete query.low_stock;
+  const result = await getRecords<StockItem>("stock_items", query);
+  if (result.success && lowStock) {
+    result.data = (result.data || []).filter(
+      (i) => typeof i.min_quantity === "number" && i.quantity < i.min_quantity
+    );
+  }
+  return result;
+};
+
+export const getComponents = (query: Record<string, unknown> = {}) =>
+  getRecords<Component>("components", query);
+
+export const getComponentById = (id: string) =>
+  getRecordById<Component>("components", id);
+
+export const createComponent = (data: Partial<Component>) =>
+  createRecord<Component>("components", data);
+
+export const updateComponent = (id: string, data: Partial<Component>) =>
+  updateRecord<Component>("components", id, data);
+
+export const deleteComponent = (id: string) =>
+  deleteRecord("components", id);
+

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -9,3 +9,5 @@ export function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
   );
 }
+
+export const createSupabaseClient = createClient;


### PR DESCRIPTION
## Summary
- restore generic database utilities in `src/lib/data-hooks`
- alias `createSupabaseClient` in Supabase client
- fix imports in ClientForm and SupplierForm
- update AGENTS and CHECKLIST docs

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516e87d3c88329b3b060769fc320c8