### PR TITLE
Fix Supabase session handling in Next.js app

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,12 +1,7 @@
 // src/app/(auth)/login/page.tsx
-"use client";
-
-import * as React from "react";
 import LoginForm from "./components/LoginForm";
 
-const LoginPage: React.FC = (): React.ReactElement => {
+export default function LoginPage() {
   return <LoginForm />;
-};
-
-export default LoginPage;
+}
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+  const supabase = createRouteHandlerClient({ cookies });
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -71,15 +71,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const loadUserAndPermissions = async () => {
       setIsLoading(true);
       try {
-        // Verificar usuário autenticado de forma segura
-        const { data: { user }, error: userError } = await supabase.auth.getUser();
+        // Verificar sessão do usuário de forma segura
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
 
-        if (userError) {
-          console.error("Erro ao obter usuário:", userError);
+        if (sessionError) {
+          console.error("Erro ao obter sessão:", sessionError);
           setIsAuthenticated(false);
           setIsLoading(false);
           return;
         }
+
+        const user = session?.user;
 
         if (!user) {
           setUser(null);

--- a/src/contexts/supabase-session-provider.tsx
+++ b/src/contexts/supabase-session-provider.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
-import { createBrowserClient } from "@supabase/ssr";
+import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
 import { useState, type ReactNode } from "react";
 import type { Database } from "@/types/supabase";
+import type { Session } from "@supabase/supabase-js";
 
 interface SupabaseSessionProviderProps {
-  initialSession: any;
+  initialSession: Session | null;
   children: ReactNode;
 }
 

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -13,8 +13,8 @@ export function useAuth(): User | null {
 
   useEffect(() => {
     const getInitialUser = async () => {
-      const { data } = await supabase.auth.getUser();
-      setUser(data.user);
+      const { data } = await supabase.auth.getSession();
+      setUser(data.session?.user ?? null);
     };
 
     void getInitialUser();

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { createBrowserClient } from "@supabase/ssr";
+import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@/types/supabase";
 
 export function createClient() {


### PR DESCRIPTION
## Summary
- ensure the Supabase browser client comes from `auth-helpers-nextjs`
- wire `SupabaseSessionProvider` with typed session
- check session with `getSession` in `AuthContext`
- use server API route for login
- update login form to call the new route

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68517e5e33b883299918e51749e83cb5