### PR TITLE
Fix Supabase auth integration with Next.js 15

### DIFF
--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -48,6 +48,7 @@ const LoginForm: React.FC = (): React.ReactElement => {
     const response = await fetch("/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
       body: JSON.stringify({
         email: values.email.trim(),
         password: values.password.trim(),

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+import type { Database } from "@/types/supabase";
 
 export async function POST(request: Request) {
   const { email, password } = await request.json();
-  const supabase = createRouteHandlerClient({ cookies });
+  const cookieStore = await cookies();
+  const supabase = createRouteHandlerClient<Database>({
+    cookies: () => cookieStore,
+  });
   const { error } = await supabase.auth.signInWithPassword({ email, password });
 
   if (error) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Inter } from "next/font/google";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@/types/supabase";
 import { AuthProvider } from "@/contexts/auth-context";
 import { ProvidersWrapper } from "@/contexts/providers-wrapper";
 import { SupabaseSessionProvider } from "@/contexts/supabase-session-provider";
@@ -20,7 +21,10 @@ export interface LayoutProps {
 }
 
 const RootLayout = async ({ children }: LayoutProps): Promise<React.ReactElement> => {
-  const supabase = createServerComponentClient({ cookies });
+  const cookieStore = await cookies();
+  const supabase = createServerComponentClient<Database>({
+    cookies: () => cookieStore,
+  });
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/src/contexts/supabase-session-provider.tsx
+++ b/src/contexts/supabase-session-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
-import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
 import { useState, type ReactNode } from "react";
 import type { Database } from "@/types/supabase";
 import type { Session } from "@supabase/supabase-js";
@@ -13,10 +13,10 @@ interface SupabaseSessionProviderProps {
 
 export function SupabaseSessionProvider({ initialSession, children }: SupabaseSessionProviderProps) {
   const [supabase] = useState(() =>
-    createBrowserClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    )
+    createBrowserSupabaseClient<Database>({
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    })
   );
 
   return (

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -19,8 +19,16 @@ export function useAuth(): User | null {
 
     void getInitialUser();
 
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
+    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+      if (
+        event === "INITIAL_SESSION" ||
+        event === "SIGNED_IN" ||
+        event === "TOKEN_REFRESHED"
+      ) {
+        setUser(session?.user ?? null);
+      } else if (event === "SIGNED_OUT") {
+        setUser(null);
+      }
     });
 
     return () => {

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,13 +1,13 @@
 "use client";
 
-import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
 import type { Database } from "@/types/supabase";
 
 export function createClient() {
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || "",
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
-  );
+  return createBrowserSupabaseClient<Database>({
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  });
 }
 
 export const createSupabaseClient = createClient;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -4,5 +4,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ExtendedDatabase } from "@/types/extended-supabase";
 
 export async function createSupabaseServerClient(): Promise<SupabaseClient<ExtendedDatabase>> {
-  return createServerComponentClient<ExtendedDatabase>({ cookies });
+  const cookieStore = await cookies();
+  return createServerComponentClient<ExtendedDatabase>({
+    cookies: () => cookieStore,
+  });
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { createMiddlewareSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs";
 import { canAccessRoute } from "@/lib/auth/roles";
 
 export async function middleware(request: NextRequest) {
   try {
     const response = NextResponse.next();
-    const supabase = createMiddlewareSupabaseClient({ req: request, res: response });
+    const supabase = createMiddlewareClient({ req: request, res: response });
 
     const {
       data: { session },


### PR DESCRIPTION
## Summary
- use `createBrowserSupabaseClient` for client-side Supabase
- update session provider
- await `cookies()` in API route and server client creation
- change middleware to `createMiddlewareClient`
- update auth hook to handle INITIAL_SESSION events
- include credentials on login fetch

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685181b6decc83298d92c23f10b700e2