### PR TITLE
fix auth client cookies

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ import { createServerClient } from '@supabase/ssr'
 import type { Database } from '@/lib/database.types'
 
 export async function POST(req: Request) {
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { SupabaseSessionProvider } from '@/contexts/supabase-session-provider'
 import { createClient } from '@/lib/supabase/server'
 
 export default async function RootLayout({ children }) {
-  const supabase = createClient()
+  const supabase = await createClient()
   const { data: { session } } = await supabase.auth.getSession()
 
   return (

--- a/src/contexts/supabase-session-provider.tsx
+++ b/src/contexts/supabase-session-provider.tsx
@@ -5,7 +5,12 @@ import { useState } from 'react'
 import type { Database } from '@/lib/database.types'
 
 export function SupabaseSessionProvider({ initialSession, children }) {
-  const [supabaseClient] = useState(() => createBrowserClient<Database>())
+  const [supabaseClient] = useState(() =>
+    createBrowserClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+  )
   return (
     <SessionContextProvider supabaseClient={supabaseClient} initialSession={initialSession}>
       {children}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,10 @@
 import { createBrowserClient } from '@supabase/ssr'
 import type { Database } from '@/lib/database.types'
 
-export const createClient = () => createBrowserClient<Database>()
+export const createClient = () =>
+  createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
 
 export const createSupabaseClient = createClient

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -2,8 +2,8 @@ import { cookies } from 'next/headers'
 import { createServerClient } from '@supabase/ssr'
 import type { Database } from '@/lib/database.types'
 
-export const createClient = () => {
-  const cookieStore = cookies()
+export const createClient = async () => {
+  const cookieStore = await cookies()
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,22 +1,16 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { createServerClient } from '@supabase/ssr'
+import { createMiddlewareClient } from '@supabase/ssr'
 import type { Database } from '@/lib/database.types'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
-  const supabase = createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => req.cookies.getAll().map(c => ({ name: c.name, value: c.value })),
-        setAll: cookies => {
-          cookies.forEach(c => res.cookies.set(c.name, c.value))
-        }
-      }
-    }
-  )
+  const supabase = createMiddlewareClient<Database>({
+    req,
+    res,
+    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  })
   await supabase.auth.getSession()
   return res
 }


### PR DESCRIPTION
## Summary
- fix SupabaseSessionProvider client env
- load env vars in supabase browser client
- support async cookies in login route and server
- update middleware to createMiddlewareClient
- adjust RootLayout to await server client

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851920cfeb48329bb8cf9f363bee362