### PR TITLE
Fix Supabase auth integration

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,22 +1,11 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { createServerClient } from '@supabase/ssr'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies()
-  const supabase = createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll().map(c => ({ name: c.name, value: c.value })),
-        setAll: cookies => {
-          cookies.forEach(c => cookieStore.set(c.name, c.value))
-        }
-      }
-    }
-  )
+  const cookieStore = cookies()
+  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore })
 
   const { email, password } = await req.json()
   const { error } = await supabase.auth.signInWithPassword({ email, password })

--- a/src/contexts/supabase-session-provider.tsx
+++ b/src/contexts/supabase-session-provider.tsx
@@ -1,15 +1,12 @@
 'use client'
-import { createBrowserClient } from '@supabase/ssr'
 import { SessionContextProvider } from '@supabase/auth-helpers-react'
+import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
 import { useState } from 'react'
 import type { Database } from '@/lib/database.types'
 
 export function SupabaseSessionProvider({ initialSession, children }) {
   const [supabaseClient] = useState(() =>
-    createBrowserClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    )
+    createPagesBrowserClient<Database>()
   )
   return (
     <SessionContextProvider supabaseClient={supabaseClient} initialSession={initialSession}>

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -19,10 +19,10 @@ export function useAuth(): User | null {
 
     void getInitialUser();
 
-    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === "INITIAL_SESSION" || event === "SIGNED_IN") {
-        setUser(session?.user ?? null);
-      } else if (event === "SIGNED_OUT") {
+    const { data: listener } = supabase.auth.onAuthStateChange(event => {
+      if (event.event === "SIGNED_IN" || event.event === "INITIAL_SESSION") {
+        setUser(event.session?.user ?? null);
+      } else if (event.event === "SIGNED_OUT") {
         setUser(null);
       }
     });

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,10 +1,6 @@
-import { createBrowserClient } from '@supabase/ssr'
+import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
-export const createClient = () =>
-  createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+export const createClient = () => createPagesBrowserClient<Database>()
 
 export const createSupabaseClient = createClient

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,17 +1,6 @@
 import { cookies } from 'next/headers'
-import { createServerClient } from '@supabase/ssr'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
-export const createClient = async () => {
-  const cookieStore = await cookies()
-  return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll().map(c => ({ name: c.name, value: c.value })),
-        setAll: () => {}
-      }
-    }
-  )
-}
+export const createClient = async () =>
+  createServerComponentClient<Database>({ cookies: () => cookies() })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { createMiddlewareClient } from '@supabase/ssr'
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
-  const supabase = createMiddlewareClient<Database>({
-    req,
-    res,
-    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  })
+  const supabase = createMiddlewareClient<Database>({ req, res })
   await supabase.auth.getSession()
   return res
 }


### PR DESCRIPTION
## Summary
- fix Supabase session provider to use `createPagesBrowserClient`
- adjust browser/client Supabase factory
- update server client with `createServerComponentClient`
- update API login route to use `createRouteHandlerClient`
- fix auth event handling in `useAuth`
- switch middleware to helper package

## Testing
- `npm install`
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6851979a4eac8329a429ea167e1a6ef1