### PR TITLE
Fix Supabase cookies call in login route

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,8 +4,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies()
-  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore })
+  const supabase = createRouteHandlerClient<Database>({ cookies })
 
   const { email, password } = await req.json()
   const { error } = await supabase.auth.signInWithPassword({ email, password })


### PR DESCRIPTION
## Summary
- adjust login route to rely on the async `cookies` helper

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: needs next package)*


------
https://chatgpt.com/codex/tasks/task_e_6852e42e6e308329a7a6e1a487dbf4e9