### PR TITLE
fix: async cookies in server supabase client

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -2,5 +2,7 @@ import { cookies } from 'next/headers'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/lib/database.types'
 
-export const createClient = () =>
-  createServerComponentClient<Database>({ cookies })
+export const createClient = async () => {
+  const cookieStore = await cookies()
+  return createServerComponentClient<Database>({ cookies: () => cookieStore })
+}


### PR DESCRIPTION
## Summary
- use awaited cookies when creating server-side Supabase client

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: needs next package)*

------
https://chatgpt.com/codex/tasks/task_e_68543140fcec8329b6ed3ef6db45ea5c