### PR TITLE
Remove getSession usage in server components

### DIFF
--- a/src/app/(dashboard)/clientes/page.tsx
+++ b/src/app/(dashboard)/clientes/page.tsx
@@ -7,15 +7,11 @@ import ClientesPage from '@/modules/clientes/ClientesPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/(dashboard)/compras/page.tsx
+++ b/src/app/(dashboard)/compras/page.tsx
@@ -7,15 +7,11 @@ import ComprasPage from '@/modules/compras/ComprasPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/(dashboard)/fornecedores/page.tsx
+++ b/src/app/(dashboard)/fornecedores/page.tsx
@@ -7,15 +7,11 @@ import FornecedoresPage from '@/modules/fornecedores/FornecedoresPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/(dashboard)/logistica/page.tsx
+++ b/src/app/(dashboard)/logistica/page.tsx
@@ -7,15 +7,11 @@ import LogisticaPage from '@/modules/logistica/LogisticaPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/(dashboard)/pedidos/page.tsx
+++ b/src/app/(dashboard)/pedidos/page.tsx
@@ -7,15 +7,11 @@ import PedidosPage from '@/modules/pedidos/PedidosPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/(dashboard)/produtos/page.tsx
+++ b/src/app/(dashboard)/produtos/page.tsx
@@ -7,15 +7,11 @@ import ProdutosPage from '@/modules/produtos/ProdutosPage'
 export default async function Page() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  const {
     data: { user },
     error,
   } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,13 +16,14 @@ export const metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
 
   return (
     <html lang="pt-BR">
       <body className={inter.className}>
-        <SupabaseSessionProvider initialSession={session}>
+        <SupabaseSessionProvider initialSession={null}>
           <AuthContextProvider>
             {children}
           </AuthContextProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,11 @@ import type { Database } from '@/lib/database.types'
 export default async function Home() {
   const supabase = createServerComponentClient<Database>({ cookies })
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (!user) {
     redirect('/login')
   }
 

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -71,17 +71,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const loadUserAndPermissions = async () => {
       setIsLoading(true);
       try {
-        // Verificar sessão do usuário de forma segura
-        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+        // Obter usuário autenticado de forma segura
+        const {
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
 
-        if (sessionError) {
-          console.error("Erro ao obter sessão:", sessionError);
+        if (userError) {
+          console.error("Erro ao obter usuário:", userError);
           setIsAuthenticated(false);
           setIsLoading(false);
           return;
         }
-
-        const user = session?.user;
 
         if (!user) {
           setUser(null);

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -13,8 +13,8 @@ export function useAuth(): User | null {
 
   useEffect(() => {
     const getInitialUser = async () => {
-      const { data } = await supabase.auth.getSession();
-      setUser(data.session?.user ?? null);
+      const { data } = await supabase.auth.getUser();
+      setUser(data.user ?? null);
     };
 
     void getInitialUser();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,6 @@ import type { Database } from '@/lib/database.types'
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
   const supabase = createMiddlewareClient<Database>({ req, res })
-  await supabase.auth.getSession()
+  await supabase.auth.getUser()
   return res
 }


### PR DESCRIPTION
## Summary
- eliminate `supabase.auth.getSession()` from server pages and layout
- rely on `supabase.auth.getUser()` for auth checks
- update auth context and hooks
- ensure middleware refreshes user via `getUser`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68543f06b070832992d6eaa59343e3b4