### PR TITLE
Fix async cookie usage for Supabase

### DIFF
--- a/src/app/(dashboard)/clientes/page.tsx
+++ b/src/app/(dashboard)/clientes/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import ClientesPage from '@/modules/clientes/ClientesPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/(dashboard)/compras/page.tsx
+++ b/src/app/(dashboard)/compras/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import ComprasPage from '@/modules/compras/ComprasPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/(dashboard)/fornecedores/page.tsx
+++ b/src/app/(dashboard)/fornecedores/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import FornecedoresPage from '@/modules/fornecedores/FornecedoresPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/(dashboard)/logistica/page.tsx
+++ b/src/app/(dashboard)/logistica/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import LogisticaPage from '@/modules/logistica/LogisticaPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/(dashboard)/pedidos/page.tsx
+++ b/src/app/(dashboard)/pedidos/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import PedidosPage from '@/modules/pedidos/PedidosPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/(dashboard)/produtos/page.tsx
+++ b/src/app/(dashboard)/produtos/page.tsx
@@ -1,11 +1,9 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import ProdutosPage from '@/modules/produtos/ProdutosPage'
 
 export default async function Page() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,7 @@
 import './globals.css'
 import { SupabaseSessionProvider } from '@/contexts/supabase-session-provider'
 import { AuthContextProvider } from '@/contexts/auth-context'
-import { cookies } from 'next/headers'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 import { Inter } from 'next/font/google'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -14,7 +12,7 @@ export const metadata = {
 }
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,8 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import { createClient } from '@/lib/supabase/server'
 
 export default async function Home() {
-  const supabase = createServerComponentClient<Database>({ cookies })
+  const supabase = await createClient()
   const {
     data: { user },
     error,


### PR DESCRIPTION
## Summary
- create a server supabase client once and await cookies
- update dashboard and root pages to use `await createClient()`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: needs next package)*

------
https://chatgpt.com/codex/tasks/task_e_68544e4ebc1c832982d0c294d43a5104