### PR TITLE
Fix creation forms

### DIFF
--- a/src/app/(dashboard)/clientes/_components/ClientForm.tsx
+++ b/src/app/(dashboard)/clientes/_components/ClientForm.tsx
@@ -20,7 +20,6 @@ import { toast } from "sonner";
 import { createRecord, updateRecord } from "@/lib/data-hooks";
 import type { Client } from "@/types/schema";
 import { Switch } from "@/components/ui/switch";
-import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 
 // Define Zod schema para validação do formulário de cliente
@@ -61,7 +60,6 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
     },
   });
 
-  const supabase = createClient();
   const router = useRouter();
 
   async function onSubmit(values: ClientFormValues) {
@@ -82,12 +80,11 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
           toast.error('Erro ao salvar cliente');
         }
       } else {
-        // Criar novo cliente diretamente via Supabase
-        const { error } = await supabase.from('clients').insert(clientData);
+        // Criar novo cliente
+        const result = await createRecord<Client>('clients', clientData);
 
-        if (error) {
-          toast.error('Erro ao salvar cliente: ' + error.message);
-          console.warn('Erro Supabase insert:', error);
+        if (!result.success) {
+          toast.error('Erro ao salvar cliente: ' + result.error);
         } else {
           toast.success('Cliente salvo com sucesso!');
           router.push('/clientes');

--- a/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
+++ b/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
@@ -71,13 +71,13 @@ export function SupplierForm({ initialData, onSuccess }: SupplierFormProps) {
       };
       
       let result;
-      
+
       if (initialData?.id) {
         // Atualizar fornecedor existente
-        result = await updateRecord('suppliers', initialData.id, supplierData);
+        result = await updateRecord<Supplier>('suppliers', initialData.id, supplierData);
       } else {
         // Criar novo fornecedor
-        result = await createRecord('suppliers', supplierData);
+        result = await createRecord<Supplier>('suppliers', supplierData);
       }
       
       if (result.success) {


### PR DESCRIPTION
## Summary
- handle client creation with typed `createRecord`
- type supplier create/update calls
- support creating supplies in `InsumoForm`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: requires installing next)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8691fe4832992178e5fa3f06292