### PR TITLE
Fix record creation forms and helper

### DIFF
--- a/src/app/(dashboard)/clientes/_components/ClientForm.tsx
+++ b/src/app/(dashboard)/clientes/_components/ClientForm.tsx
@@ -64,33 +64,35 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
 
   async function onSubmit(values: ClientFormValues) {
     try {
-      // Preparar dados para envio
       const clientData = {
         ...values,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       };
-      
-      if (initialData?.id) {
-        // Atualizar cliente existente
-        const result = await updateRecord('clients', initialData.id, clientData);
-        if (result.success) {
-          toast.success('Cliente atualizado com sucesso!');
-          onSuccess?.();
-        } else {
-          toast.error('Erro ao salvar cliente');
-        }
-      } else {
-        // Criar novo cliente
-        const result = await createRecord<Client>('clients', clientData);
 
-        if (!result.success) {
-          toast.error('Erro ao salvar cliente: ' + result.error);
-        } else {
-          toast.success('Cliente salvo com sucesso!');
-          router.push('/clientes');
-          onSuccess?.();
+      if (initialData?.id) {
+        const { error } = await updateRecord<Client>(
+          "clients",
+          initialData.id,
+          clientData,
+        );
+        if (error) {
+          toast.error("Erro ao salvar cliente");
+          console.error(error);
+          return;
         }
+        toast.success("Cliente atualizado com sucesso");
+      } else {
+        const { error } = await createRecord<Client>("clients", clientData);
+        if (error) {
+          toast.error("Erro ao criar cliente");
+          console.error(error);
+          return;
+        }
+        toast.success("Cliente criado com sucesso");
       }
+
+      onSuccess?.();
+      router.push("/clientes");
     } catch (error) {
       console.error("Erro ao salvar cliente:", error);
       toast.error("Erro ao salvar cliente");

--- a/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
+++ b/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { createRecord, updateRecord } from "@/lib/data-hooks";
 import { Switch } from "@/components/ui/switch";
 import type { Supplier } from "@/types/schema";
+import { useRouter } from "next/navigation";
 
 // Define Zod schema para validação do formulário de fornecedor
 const supplierFormSchema = z.object({
@@ -62,35 +63,44 @@ export function SupplierForm({ initialData, onSuccess }: SupplierFormProps) {
     },
   });
 
+  const router = useRouter();
+
   const onSubmit: SubmitHandler<SupplierFormValues> = async (values) => {
     try {
-      // Preparar dados para envio
       const supplierData = {
         ...values,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       };
-      
-      let result;
 
       if (initialData?.id) {
-        // Atualizar fornecedor existente
-        result = await updateRecord<Supplier>('suppliers', initialData.id, supplierData);
+        const { error } = await updateRecord<Supplier>(
+          "suppliers",
+          initialData.id,
+          supplierData,
+        );
+        if (error) {
+          toast.error("Erro ao salvar fornecedor");
+          console.error(error);
+          return;
+        }
+        toast.success("Fornecedor atualizado com sucesso");
       } else {
-        // Criar novo fornecedor
-        result = await createRecord<Supplier>('suppliers', supplierData);
+        const { error } = await createRecord<Supplier>("suppliers", supplierData);
+        if (error) {
+          toast.error("Erro ao criar fornecedor");
+          console.error(error);
+          return;
+        }
+        toast.success("Fornecedor criado com sucesso");
       }
-      
-      if (result.success) {
-        toast.success(initialData ? "Fornecedor atualizado com sucesso" : "Fornecedor criado com sucesso");
-        onSuccess?.();
-      } else {
-        toast.error("Erro ao salvar fornecedor");
-      }
+
+      onSuccess?.();
+      router.push("/fornecedores");
     } catch (error) {
       console.error("Erro ao salvar fornecedor:", error);
       toast.error("Erro ao salvar fornecedor");
     }
-  }
+  };
 
   return (
     <Form {...form}>

--- a/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
+++ b/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { createRecord, updateRecord } from "@/lib/data-hooks";
 import type { StockItem } from "@/types/schema";
 import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 const formSchema = z.object({
   id: z.string().optional(), // utilizado apenas na edição
@@ -42,34 +43,43 @@ export function InsumoForm({ initialData, onSuccess }: InsumoFormProps): React.J
     },
   });
 
+  const router = useRouter();
+
   async function onSubmit(data: FormValues): Promise<void> {
     try {
-      let result;
-
       if (initialData?.id) {
-        // Atualizar insumo existente
-        result = await updateRecord<StockItem>("stock_items", initialData.id, {
-          name: data.name,
-          description: data.description,
-          quantity: data.quantity,
-          unit: data.unit,
-        });
+        const { error } = await updateRecord<StockItem>(
+          "stock_items",
+          initialData.id,
+          {
+            name: data.name,
+            description: data.description,
+            quantity: data.quantity,
+            unit: data.unit,
+          },
+        );
+        if (error) {
+          toast.error("Erro ao salvar insumo");
+          console.error(error);
+          return;
+        }
       } else {
-        // Criar novo insumo
-        result = await createRecord<StockItem>("stock_items", {
+        const { error } = await createRecord<StockItem>("stock_items", {
           name: data.name,
           description: data.description,
           quantity: data.quantity,
           unit: data.unit,
         });
+        if (error) {
+          toast.error("Erro ao criar insumo");
+          console.error(error);
+          return;
+        }
       }
 
-      if (result.success) {
-        toast.success("Insumo salvo com sucesso");
-        onSuccess();
-      } else {
-        toast.error("Erro ao salvar insumo");
-      }
+      toast.success("Insumo salvo com sucesso");
+      onSuccess();
+      router.push("/insumos");
     } catch (error) {
       console.error("Erro ao salvar insumo:", error);
       toast.error("Erro ao salvar insumo");

--- a/src/lib/data-hooks.ts
+++ b/src/lib/data-hooks.ts
@@ -101,8 +101,16 @@ export async function createRecord<T>(
       .single()
       .returns<T>();
     if (error) return handleSupabaseError(error);
+    if (!result) {
+      console.error("createRecord returned no data for table", table);
+      return {
+        success: false,
+        error: "Erro desconhecido ao criar registro",
+      } as const;
+    }
     return { success: true, data: result as T };
   } catch (err) {
+    console.error("createRecord unexpected error:", err);
     return handleSupabaseError(err);
   }
 }


### PR DESCRIPTION
## Summary
- add fallback logging to `createRecord`
- update ClientForm submission workflow
- update SupplierForm with router push and error handling
- improve InsumoForm submission logic

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685aae3261c88329af7ed2249a8caa01