### PR TITLE
Implement toast notifications for forms

### DIFF
--- a/src/app/(dashboard)/compras/_components/PurchaseOrderForm.tsx
+++ b/src/app/(dashboard)/compras/_components/PurchaseOrderForm.tsx
@@ -18,6 +18,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { CalendarIcon, PlusCircle, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { ptBR } from 'date-fns/locale';
@@ -115,7 +116,7 @@ export function PurchaseOrderForm({ initialData, onSuccess }: PurchaseOrderFormP
 
       } catch (error) {
         console.error("Error fetching related data for Purchase Order:", error);
-        // TODO: Show error toast to user
+        toast.error("Erro ao carregar dados relacionados");
       } finally {
         setLoadingRelatedData(false);
       }
@@ -196,14 +197,16 @@ export function PurchaseOrderForm({ initialData, onSuccess }: PurchaseOrderFormP
             .insert(itemsToInsert);
         if (insertItemsError) throw insertItemsError;
 
-        console.log("Purchase Order saved successfully!");
+        toast.success("Pedido de compra salvo com sucesso");
         onSuccess?.();
-        // TODO: Add success toast
 
     } catch (error) {
         console.error("Failed to save purchase order:", error);
-        // TODO: Show error message to user (toast)
-        alert(`Erro ao salvar ordem de compra: ${error instanceof Error ? error.message : String(error)}`);
+        toast.error(
+          `Erro ao salvar ordem de compra: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
     }
   }
 

--- a/src/app/(dashboard)/estoque/grupos/page.tsx
+++ b/src/app/(dashboard)/estoque/grupos/page.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { toast } from "sonner";
 // TODO: Import AlertDialog for delete confirmation
 
 // Fetch real group data from Supabase (Placeholder)
@@ -70,7 +71,7 @@ export default function GruposEstoquePage() {
     setIsFormOpen(false);
     setEditingGroup(null);
     fetchAndSetGroups();
-    // TODO: Add toast notification for success
+    toast.success("Grupo salvo com sucesso");
   };
 
   const handleEdit = React.useCallback((group: GrupoDeInsumo) => {
@@ -84,13 +85,11 @@ export default function GruposEstoquePage() {
       try {
         await deleteGroupAPI(groupId);
         console.log(`Group ${groupId} deleted successfully.`);
-        alert(`Grupo "${groupName}" excluído com sucesso (placeholder).`);
         fetchAndSetGroups(); // Refresh data
-        // TODO: Add toast notification for success
+        toast.success(`Grupo "${groupName}" excluído`);
       } catch (error) {
         console.error("Error deleting group:", error);
-        alert(`Erro ao excluir grupo "${groupName}".`);
-        // TODO: Add toast notification for error
+        toast.error(`Erro ao excluir grupo "${groupName}"`);
       }
     }
   }, []);

--- a/src/app/(dashboard)/estoque/localizacoes/page.tsx
+++ b/src/app/(dashboard)/estoque/localizacoes/page.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { toast } from "sonner";
 // TODO: Import AlertDialog for delete confirmation
 
 // Fetch real location data from Supabase (Placeholder)
@@ -70,7 +71,7 @@ export default function LocalizacoesEstoquePage() {
     setIsFormOpen(false);
     setEditingLocation(null);
     fetchAndSetLocations();
-    // TODO: Add toast notification for success
+    toast.success("Localização salva com sucesso");
   };
 
   const handleEdit = React.useCallback((location: LocalizacaoEstoque) => {
@@ -84,13 +85,11 @@ export default function LocalizacoesEstoquePage() {
       try {
         await deleteLocationAPI(locationId);
         console.log(`Location ${locationId} deleted successfully.`);
-        alert(`Localização "${locationName}" excluída com sucesso (placeholder).`);
         fetchAndSetLocations(); // Refresh data
-        // TODO: Add toast notification for success
+        toast.success(`Localização "${locationName}" excluída`);
       } catch (error) {
         console.error("Error deleting location:", error);
-        alert(`Erro ao excluir localização "${locationName}".`);
-        // TODO: Add toast notification for error
+        toast.error(`Erro ao excluir localização "${locationName}"`);
       }
     }
   }, []);

--- a/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
+++ b/src/app/(dashboard)/estoque/movimentacoes/_components/MovementsPageClient.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Button } from "@/components/ui/button";
 import { PlusCircle, Download, Upload } from "lucide-react"; // Add icons for import/export
+import { toast } from "sonner";
 import { DataTable } from "@/components/ui/data-table";
 import { movementColumns, type StockMovement } from "./MovementColumns";
 import { MovementForm } from "./MovementForm";
@@ -41,7 +42,7 @@ export function MovementsPageClient() {
   const handleSuccess = () => {
     setIsFormOpen(false);
     fetchAndSetMovements();
-    // TODO: Add toast notification for success
+    toast.success("Movimentação registrada com sucesso");
   };
 
   // Placeholder functions for import/export

--- a/src/app/(dashboard)/pedidos/_components/OrderForm.tsx
+++ b/src/app/(dashboard)/pedidos/_components/OrderForm.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
+import { toast } from "sonner";
 import { CalendarIcon, PlusCircle, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
@@ -129,7 +130,7 @@ export function OrderForm({ initialData, onSuccess }: OrderFormProps) {
 
       } catch (error) {
         console.error("Error fetching related data:", error);
-        // TODO: Show error toast to user
+        toast.error("Erro ao carregar dados relacionados");
       } finally {
         setLoadingRelatedData(false);
       }
@@ -211,13 +212,14 @@ export function OrderForm({ initialData, onSuccess }: OrderFormProps) {
         if (insertItemsError) throw insertItemsError;
 
         console.log("Order saved successfully!");
+        toast.success("Pedido salvo com sucesso");
         onSuccess?.(); // Close dialog/sheet on success
-        // TODO: Add success toast
 
     } catch (error) {
         console.error("Failed to save order:", error);
-        // TODO: Show error message to user (toast)
-        alert(`Erro ao salvar pedido: ${error instanceof Error ? error.message : String(error)}`);
+        toast.error(
+          `Erro ao salvar pedido: ${error instanceof Error ? error.message : String(error)}`
+        );
     }
   }
 

--- a/src/app/(dashboard)/producao/[id]/page.tsx
+++ b/src/app/(dashboard)/producao/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ArrowLeft, Edit, Trash2, CheckCircle, Clock } from "lucide-react";
+import { toast } from "sonner";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
@@ -123,7 +124,7 @@ export default function ProductionOrderDetailsPage(): React.ReactElement | null 
 
       } catch (error) {
         console.error("Error fetching production order details:", error);
-        // TODO: Show error toast
+        toast.error("Erro ao buscar detalhes da produção");
       } finally {
         setLoading(false);
       }
@@ -154,10 +155,10 @@ export default function ProductionOrderDetailsPage(): React.ReactElement | null 
       
       // Navigate back to production orders list
       router.push("/producao");
-      // TODO: Show success toast
+      toast.success("Ordem de produção excluída");
     } catch (error) {
       console.error("Error deleting production order:", error);
-      // TODO: Show error toast
+      toast.error("Erro ao excluir ordem de produção");
     } finally {
       setDeleteDialogOpen(false);
     }
@@ -260,11 +261,11 @@ export default function ProductionOrderDetailsPage(): React.ReactElement | null 
 
       if (stagesError) throw stagesError;
       setStages(stagesData || []);
-      
-      // TODO: Show success toast
+
+      toast.success("Produção concluída com sucesso");
     } catch (error) {
       console.error("Error completing production order:", error);
-      // TODO: Show error toast
+      toast.error("Erro ao concluir produção");
     } finally {
       setCompleteDialogOpen(false);
     }


### PR DESCRIPTION
## Summary
- add toast feedback in PurchaseOrderForm
- add toast feedback in production order page
- show toasts in stock movement form
- show toasts when editing locations and groups
- show toast messages in OrderForm

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(fails: needs next install)*

------
https://chatgpt.com/codex/tasks/task_e_685aca2263b083299ae2357e05bed00e