### PR TITLE
Fix forms for components and supplies

### DIFF
--- a/sql/components_stock_items_policies.sql
+++ b/sql/components_stock_items_policies.sql
@@ -1,0 +1,13 @@
+-- Enable RLS and allow insert for components
+ALTER TABLE components ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "allow insert" ON components;
+CREATE POLICY "allow insert" ON components
+  FOR INSERT TO authenticated USING (true);
+
+-- Enable RLS and allow insert for stock_items
+ALTER TABLE stock_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "allow insert" ON stock_items;
+CREATE POLICY "allow insert" ON stock_items
+  FOR INSERT TO authenticated USING (true);

--- a/src/app/(dashboard)/componentes/_components/ComponentForm.tsx
+++ b/src/app/(dashboard)/componentes/_components/ComponentForm.tsx
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
-import { updateRecord } from "@/lib/data-hooks";
+import { useRouter } from "next/navigation";
 import { Switch } from "@/components/ui/switch";
 import type { Component } from "@/types/schema";
 
@@ -39,6 +39,7 @@ interface ComponentFormProps {
 }
 
 export function ComponentForm({ initialData, onSuccess }: ComponentFormProps) {
+  const router = useRouter();
   const form = useForm<ComponentFormValues>({
     resolver: zodResolver(componentFormSchema) as Resolver<ComponentFormValues>,
     defaultValues: {
@@ -71,6 +72,7 @@ export function ComponentForm({ initialData, onSuccess }: ComponentFormProps) {
         }
         toast.success("Componente atualizado com sucesso");
         onSuccess?.();
+        router.push("/componentes");
       } else {
         const { error } = await supabase
           .from("components")
@@ -84,6 +86,7 @@ export function ComponentForm({ initialData, onSuccess }: ComponentFormProps) {
         }
         toast.success("Componente criado com sucesso");
         onSuccess?.();
+        router.push("/componentes");
       }
     } catch (error) {
       console.error("Erro ao salvar componente:", error);

--- a/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
+++ b/src/app/(dashboard)/insumos/_components/InsumoForm.tsx
@@ -24,7 +24,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 interface InsumoFormProps {
   initialData?: Partial<FormValues>;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function InsumoForm({ initialData, onSuccess }: InsumoFormProps): React.JSX.Element {
@@ -84,7 +84,7 @@ export function InsumoForm({ initialData, onSuccess }: InsumoFormProps): React.J
       }
 
       toast.success("Insumo salvo com sucesso");
-      onSuccess();
+      onSuccess?.();
       router.push("/insumos");
     } catch (error) {
       console.error("Erro ao salvar insumo:", error);


### PR DESCRIPTION
## Summary
- ensure component creation shows toast and redirects to listing
- ensure insumo form callback is optional and redirect happens after saving
- add SQL policies to enable RLS inserts for components and stock_items

## Testing
- `npm run lint`
- `npm test`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_685acea23ae083298937cc20e55bcf64