### PR TITLE
Fix components table display and supply error message

### DIFF
--- a/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
+++ b/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
@@ -44,27 +44,18 @@ export const componentColumns = (onEdit: (component: Component) => void, onDelet
   },
   {
     accessorKey: "name",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Nome
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
-    cell: ({ row }) => (
-      <Link href={`/componentes/${row.original.id}`} className="font-medium text-blue-600 hover:underline">
-        {row.getValue("name")}
-      </Link>
-    ),
+    header: "Nome",
+    cell: ({ row }) => row.getValue("name") || "-",
   },
   {
     accessorKey: "description",
     header: "Descrição",
-    cell: ({ row }) => <div className="max-w-[300px] truncate">{row.original.description || "-"}</div>,
+    cell: ({ row }) => row.getValue("description") || "-",
+  },
+  {
+    accessorKey: "unit_of_measurement.abbreviation",
+    header: "Unidade",
+    cell: ({ row }) => row.original.unit_of_measurement?.abbreviation || "-",
   },
   {
     accessorKey: "is_active",

--- a/src/lib/data-hooks.ts
+++ b/src/lib/data-hooks.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { toast } from "sonner";
 
 // Tipagem comum para retorno de dados
 interface SupabaseResult<T> {
@@ -64,7 +65,8 @@ export async function getSupplies(filters: Record<string, unknown> = {}): Promis
   const { data, error } = await query;
 
   if (error) {
-    console.error("Erro ao buscar insumos:", error);
+    console.error("Erro ao buscar insumos:", error?.message || error);
+    toast.error("Erro ao buscar insumos: " + (error?.message || ""));
     return { success: false, error: error.message };
   }
 


### PR DESCRIPTION
## Summary
- show component name/description/unit correctly
- display error toast when failing to fetch supplies

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx --yes next build` *(fails: cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_685aeb8916a48329af2e03e86ca191f8