### PR TITLE
Fix unit joins for components and supplies

### DIFF
--- a/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
+++ b/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
@@ -14,11 +14,13 @@ export type Component = {
   id: string;
   name: string;
   description?: string | null;
+  unit_of_measurement?: {
+    abbreviation: string;
+  } | null;
   image_url?: string | null;
   is_active?: boolean | null;
   created_at: string;
   updated_at?: string | null;
-  // Relacionamentos podem ser adicionados aqui conforme necessário
 };
 
 // Define columns as a function to accept callbacks
@@ -53,9 +55,10 @@ export const componentColumns = (onEdit: (component: Component) => void, onDelet
     cell: ({ row }) => row.getValue("description") || "-",
   },
   {
-    accessorKey: "unit_of_measurement.abbreviation",
+    id: "unit",
     header: "Unidade",
-    cell: ({ row }) => row.original.unit_of_measurement?.abbreviation || "-",
+    accessorFn: (row) => row.unit_of_measurement?.abbreviation ?? "-",
+    cell: ({ row }) => row.getValue("unit") as string,
   },
   {
     accessorKey: "is_active",

--- a/src/app/(dashboard)/insumos/_components/InsumoColumns.tsx
+++ b/src/app/(dashboard)/insumos/_components/InsumoColumns.tsx
@@ -35,9 +35,9 @@ export type Insumo = {
     name: string;
   } | null;
   unit_of_measurement?: {
-    id: string;
-    name: string;
-    symbol: string;
+    id?: string;
+    name?: string;
+    abbreviation: string;
   } | null;
   supplier?: {
     id: string;
@@ -95,7 +95,7 @@ export const insumoColumns = (onEdit: (insumo: Insumo) => void, onDelete: (insum
     header: "Quantidade",
     cell: ({ row }) => {
       const quantity = row.original.quantity || 0;
-      const unit = row.original.unit_of_measurement?.symbol || "un";
+      const unit = row.original.unit_of_measurement?.abbreviation || "un";
       const minQuantity = row.original.min_quantity || 0;
       
       // Verificar se está abaixo do estoque mínimo
@@ -114,9 +114,10 @@ export const insumoColumns = (onEdit: (insumo: Insumo) => void, onDelete: (insum
     },
   },
   {
-    accessorKey: "unit_of_measurement.symbol",
+    id: "unit",
     header: "Unidade",
-    cell: ({ row }) => <div>{row.original.unit_of_measurement?.symbol || "un"}</div>,
+    accessorFn: (row) => row.unit_of_measurement?.abbreviation ?? "-",
+    cell: ({ row }) => row.getValue("unit") as string,
   },
   {
     accessorKey: "cost_price",

--- a/src/app/(dashboard)/insumos/page.tsx
+++ b/src/app/(dashboard)/insumos/page.tsx
@@ -16,7 +16,7 @@ import type { ParseError, ParseResult } from 'papaparse';
 import { saveAs } from 'file-saver';
 import { toast } from "sonner";
 import { InsumoForm } from "./_components/InsumoForm";
-import { getSupplies, useSupabaseData } from "@/lib/data-hooks";
+import { getInsumos, useSupabaseData } from "@/lib/data-hooks";
 import type { Insumo } from "./_components/InsumoColumns";
 
 interface CSVInsumoParseResult {
@@ -58,8 +58,8 @@ export default function InsumosPage() {
     { id: "supplier_id", label: "Fornecedor", type: "select", options: 
       suppliers.map(supplier => ({ value: supplier.id, label: supplier.name }))
     },
-    { id: "unit_of_measurement_id", label: "Unidade", type: "select", options: 
-      units.map(unit => ({ value: unit.id, label: `${unit.name} (${unit.symbol})` }))
+    { id: "unit_of_measurement_id", label: "Unidade", type: "select", options:
+      units.map(unit => ({ value: unit.id, label: `${unit.name} (${unit.abbreviation})` }))
     },
     { id: "low_stock", label: "Estoque Baixo", type: "boolean" }
   ];
@@ -120,7 +120,7 @@ export default function InsumosPage() {
         }
       });
 
-      const result = await getSupplies(query);
+      const result = await getInsumos(query);
       
       if (result.success) {
         setInsumos(result.data || []);
@@ -134,7 +134,7 @@ export default function InsumosPage() {
             quantity: 200,
             min_quantity: 50,
             unit_of_measurement_id: '1',
-            unit_of_measurement: { id: '1', name: 'Metro', symbol: 'm' },
+            unit_of_measurement: { id: '1', name: 'Metro', abbreviation: 'm' },
             supplier_id: '1',
             supplier: { id: '1', name: 'Fornecedor Têxtil Ltda' },
             is_active: true,
@@ -147,7 +147,7 @@ export default function InsumosPage() {
             quantity: 30,
             min_quantity: 100,
             unit_of_measurement_id: '2',
-            unit_of_measurement: { id: '2', name: 'Unidade', symbol: 'un' },
+            unit_of_measurement: { id: '2', name: 'Unidade', abbreviation: 'un' },
             supplier_id: '2',
             supplier: { id: '2', name: 'Distribuidora de Tecidos Nacional S.A.' },
             is_active: true,


### PR DESCRIPTION
## Summary
- join unit_of_measurement abbreviation when querying components and insumos
- expose abbreviation via accessorFn in ComponentColumns
- expose abbreviation via accessorFn in InsumoColumns and update sample data
- use `getInsumos` function in insumos page

## Testing
- `npx next@15.3.4 lint`
- `npm test`
- `npx next@15.3.4 build` *(fails: `Cannot read properties of null (reading 'use')` during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_685d38f05a888329bf4dd03b1ed0b43d