### PR TITLE
Fix unit join for insumos and componentes

### DIFF
--- a/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
+++ b/src/app/(dashboard)/componentes/_components/ComponentColumns.tsx
@@ -57,7 +57,7 @@ export const componentColumns = (onEdit: (component: Component) => void, onDelet
   {
     id: "unit",
     header: "Unidade",
-    accessorFn: (row) => row.unit_of_measurement?.abbreviation ?? "-",
+    accessorFn: (row) => row.unit_of_measurement?.abbreviation || "-",
     cell: ({ row }) => row.getValue("unit") as string,
   },
   {

--- a/src/app/(dashboard)/insumos/_components/InsumoColumns.tsx
+++ b/src/app/(dashboard)/insumos/_components/InsumoColumns.tsx
@@ -116,7 +116,7 @@ export const insumoColumns = (onEdit: (insumo: Insumo) => void, onDelete: (insum
   {
     id: "unit",
     header: "Unidade",
-    accessorFn: (row) => row.unit_of_measurement?.abbreviation ?? "-",
+    accessorFn: (row) => row.unit_of_measurement?.abbreviation || "-",
     cell: ({ row }) => row.getValue("unit") as string,
   },
   {

--- a/src/lib/data-hooks.ts
+++ b/src/lib/data-hooks.ts
@@ -51,7 +51,9 @@ export async function getInsumos(
     const supabase = createClient();
     let query = supabase
       .from("stock_items")
-      .select("*, unit_of_measurement:unit_of_measurement_id(abbreviation)");
+      .select(
+        "*, unit_of_measurement:unit_of_measurement_id(id, name, abbreviation)",
+      );
 
     Object.entries(filters).forEach(([key, value]) => {
       if (value !== undefined && value !== null && value !== "") {
@@ -246,7 +248,9 @@ export const getComponents = async (
     const supabase = createClient();
     let builder = supabase
       .from("components")
-      .select("*, unit_of_measurement:unit_of_measurement_id(abbreviation)");
+      .select(
+        "*, unit_of_measurement:unit_of_measurement_id(id, name, abbreviation)",
+      );
 
     Object.entries(query).forEach(([key, value]) => {
       if (value !== undefined && value !== null && value !== "") {

--- a/src/modules/componentes/ComponentesPage.tsx
+++ b/src/modules/componentes/ComponentesPage.tsx
@@ -152,7 +152,9 @@ export default function ComponentesPage() {
       if (result.success) {
         setComponents(result.data || []);
       } else {
-        setError("Nenhum componente encontrado");
+        setComponents([]);
+        setError(result.error || "Erro ao carregar componentes");
+        toast.error("Erro ao carregar componentes");
       }
     } catch (err: unknown) {
       console.error("Error fetching components:", err);

--- a/src/modules/insumos/InsumosPage.tsx
+++ b/src/modules/insumos/InsumosPage.tsx
@@ -166,43 +166,9 @@ export default function InsumosPage() {
       if (result.success) {
         setInsumos(result.data || []);
       } else {
-        // Usar dados mockados para demonstração
-        setInsumos([
-          {
-            id: "1",
-            name: "Tecido Algodão 100%",
-            sku: "TAL100",
-            quantity: 200,
-            min_quantity: 50,
-            unit_of_measurement_id: "1",
-            unit_of_measurement: { id: "1", name: "Metro", abbreviation: "m" },
-            supplier_id: "1",
-            supplier: { id: "1", name: "Fornecedor Têxtil Ltda" },
-            is_active: true,
-            created_at: new Date().toISOString(),
-          },
-          {
-            id: "2",
-            name: "Linha para Costura",
-            sku: "LIN001",
-            quantity: 30,
-            min_quantity: 100,
-            unit_of_measurement_id: "2",
-            unit_of_measurement: {
-              id: "2",
-              name: "Unidade",
-              abbreviation: "un",
-            },
-            supplier_id: "2",
-            supplier: {
-              id: "2",
-              name: "Distribuidora de Tecidos Nacional S.A.",
-            },
-            is_active: true,
-            created_at: new Date().toISOString(),
-          },
-        ]);
-        console.warn("Usando dados mockados para insumos");
+        setInsumos([]);
+        setError(result.error || "Erro ao carregar insumos");
+        toast.error("Erro ao carregar lista de insumos.");
       }
     } catch (err: unknown) {
       const error = err as Error;


### PR DESCRIPTION
## Summary
- fetch unit abbreviations correctly for components and stock items
- show errors on fetch failure
- remove mock data
- align column definitions for unit abbreviation display

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx next build` *(failed: tried to install next)*

------
https://chatgpt.com/codex/tasks/task_e_685d494a69b0832999d4770b51fe82f4