### PR TITLE
Fix client/supplier forms for proper supabase usage

### DIFF
--- a/src/app/(dashboard)/clientes/_components/ClientForm.tsx
+++ b/src/app/(dashboard)/clientes/_components/ClientForm.tsx
@@ -64,7 +64,7 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
 
   async function onSubmit(values: ClientFormValues) {
     try {
-      const supabase = createSupabaseClient();
+      const supabase = await createSupabaseClient();
       const clientData = {
         ...values,
         updated_at: new Date().toISOString(),
@@ -87,6 +87,8 @@ export function ClientForm({ initialData, onSuccess }: ClientFormProps) {
       }
 
       if (error) {
+        console.error(error);
+        console.log(clientData);
         toast.error("Erro ao salvar cliente: " + error.message);
         return;
       }

--- a/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
+++ b/src/app/(dashboard)/fornecedores/_components/SupplierForm.tsx
@@ -67,7 +67,7 @@ export function SupplierForm({ initialData, onSuccess }: SupplierFormProps) {
 
   const onSubmit: SubmitHandler<SupplierFormValues> = async (values) => {
     try {
-      const supabase = createSupabaseClient();
+      const supabase = await createSupabaseClient();
       const supplierData = {
         ...values,
         updated_at: new Date().toISOString(),
@@ -90,6 +90,8 @@ export function SupplierForm({ initialData, onSuccess }: SupplierFormProps) {
       }
 
       if (error) {
+        console.error(error);
+        console.log(supplierData);
         toast.error("Erro ao salvar fornecedor: " + error.message);
         return;
       }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
-import type { Database } from '@/lib/database.types'
+import type { Database } from '../types/supabase'
 
 export const createClient = async () => {
   const cookieStore = await cookies()


### PR DESCRIPTION
## Summary
- update server client type import
- ensure ClientForm and SupplierForm await Supabase client
- log payload and error on insert failures

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npx --yes next build` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865661a30248329a5c8c0ab4016efd6